### PR TITLE
🧪 Add unit tests for getFlagValue function

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -3,6 +3,7 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { promises as fsPromises } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import os from 'node:os';
 import path from 'node:path';
 import readline from 'node:readline/promises';
@@ -98,7 +99,7 @@ function setRuntimeConfig({ email, apiKey, host }) {
 
 const getApiEndpoint = () => `${apiHost}/mcp/generate`;
 
-const getFlagValue = (flag, list = []) => {
+export const getFlagValue = (flag, list = []) => {
   const index = list.indexOf(`--${flag}`);
   if (index !== -1 && list[index + 1] && !list[index + 1].startsWith('--')) {
     return list[index + 1];
@@ -966,7 +967,10 @@ async function main() {
   await handleCli(args);
 }
 
-main().catch((err) => {
-  console.error('[seerxo] Fatal error:', err);
-  process.exit(1);
-});
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((err) => {
+    console.error('[seerxo] Fatal error:', err);
+    process.exit(1);
+  });
+}

--- a/mcp-server.test.js
+++ b/mcp-server.test.js
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { getFlagValue } from './mcp-server.js';
+
+test('getFlagValue returns value when flag is present and followed by a valid value', () => {
+  const list = ['--foo', 'bar'];
+  assert.strictEqual(getFlagValue('foo', list), 'bar');
+});
+
+test('getFlagValue returns null when flag is missing', () => {
+  const list = ['--bar', 'baz'];
+  assert.strictEqual(getFlagValue('foo', list), null);
+});
+
+test('getFlagValue returns null when flag is the last item', () => {
+  const list = ['--foo'];
+  assert.strictEqual(getFlagValue('foo', list), null);
+});
+
+test('getFlagValue returns null when value starts with --', () => {
+  const list = ['--foo', '--bar'];
+  assert.strictEqual(getFlagValue('foo', list), null);
+});
+
+test('getFlagValue returns null with an empty list', () => {
+  const list = [];
+  assert.strictEqual(getFlagValue('foo', list), null);
+});
+
+test('getFlagValue returns null when list is not provided (tests default argument)', () => {
+  assert.strictEqual(getFlagValue('foo'), null);
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "seerxo": "mcp-server.js"
   },
   "scripts": {
-    "start": "node mcp-server.js"
+    "start": "node mcp-server.js",
+    "test": "node --test"
   },
   "keywords": [
     "mcp",


### PR DESCRIPTION
🎯 **What:** The `getFlagValue` function in `mcp-server.js` was previously untested. This PR adds unit tests for this CLI argument parsing function.

📊 **Coverage:** The new `mcp-server.test.js` covers 6 scenarios for `getFlagValue`:
1. Happy path: Flag is present and followed by a valid value.
2. Missing flag: Returns null.
3. End of list: Flag is the last item, returns null.
4. Next item is flag: The value starts with `--`, returns null.
5. Empty list: Returns null.
6. Default parameters: Missing list parameter returns null.

✨ **Result:** Test coverage improved. The file `mcp-server.js` was also updated to export the tested function and guard the top-level execution logic so that tests can be imported without triggering the CLI interface.

---
*PR created automatically by Jules for task [13794158885625372550](https://jules.google.com/task/13794158885625372550) started by @semihbugrasezer*