### PR TITLE
🧪 test: add mcp-server.js base test suite

### DIFF
--- a/mcp-server.test.js
+++ b/mcp-server.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cliPath = path.join(__dirname, 'mcp-server.js');
+
+describe('mcp-server CLI', () => {
+  it('should print version with --version', () => {
+    const output = execFileSync('node', [cliPath, '--version'], { encoding: 'utf8' });
+    expect(output.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('should print help with --help', () => {
+    const output = execFileSync('node', [cliPath, '--help'], { encoding: 'utf8' });
+    expect(output).toContain('Commands:');
+    expect(output).toContain('seerxo login');
+    expect(output).toContain('seerxo generate');
+  });
+
+  it('should require arguments for generate', () => {
+    expect.assertions(2);
+    try {
+      execFileSync('node', [cliPath, 'generate'], { encoding: 'utf8' });
+    } catch (err) {
+      expect(err.status).toBe(1);
+      expect(err.stderr).toContain('Missing argument: --product "Product name"');
+    }
+  });
+
+  it('should print error for unknown commands', () => {
+    expect.assertions(2);
+    try {
+      execFileSync('node', [cliPath, 'unknown-command'], { encoding: 'utf8' });
+    } catch (err) {
+      expect(err.status).toBe(1);
+      expect(err.stderr).toContain('Unknown command: unknown-command');
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "seerxo": "mcp-server.js"
   },
   "scripts": {
-    "start": "node mcp-server.js"
+    "start": "node mcp-server.js",
+    "test": "vitest run"
   },
   "keywords": [
     "mcp",
@@ -48,5 +49,8 @@
     "mcp-server.js",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "devDependencies": {
+    "vitest": "^4.1.4"
+  }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `mcp-server.js` file previously lacked test coverage. A new `mcp-server.test.js` file was created and configured with `vitest` to verify basic CLI behavior.

📊 **Coverage:** What scenarios are now tested
- `--version` flag functionality
- `--help` flag functionality
- Missing arguments validation for `generate` command
- Handling of unknown commands

✨ **Result:** The improvement in test coverage
We now have automated baseline testing for `mcp-server.js` via the `npm test` command ensuring core CLI paths remain functional.

---
*PR created automatically by Jules for task [10699440662970448655](https://jules.google.com/task/10699440662970448655) started by @semihbugrasezer*