### PR TITLE
🔒 Fix command injection vulnerability in URL opening

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -11,6 +11,7 @@ import { createRequire } from 'node:module';
 import { execSync, spawn } from 'node:child_process';
 import boxen from 'boxen';
 import chalk from 'chalk';
+import open from 'open';
 
 const require = createRequire(import.meta.url);
 const pkg = require('./package.json');
@@ -331,18 +332,7 @@ const runLoginCommand = async (extraArgs = [], options = {}) => {
     console.log('');
     if (safeApprovalUrl) {
       try {
-        const openCommand =
-          process.platform === 'darwin'
-            ? { cmd: 'open', args: [safeApprovalUrl] }
-            : process.platform === 'win32'
-            ? { cmd: 'cmd', args: ['/c', 'start', '', safeApprovalUrl] }
-            : { cmd: 'xdg-open', args: [safeApprovalUrl] };
-
-        const opener = spawn(openCommand.cmd, openCommand.args, {
-          stdio: 'ignore',
-          detached: true,
-        });
-        opener.unref();
+        open(safeApprovalUrl).catch(() => {});
       } catch {
       }
     }
@@ -412,17 +402,7 @@ function openUpgradeLink(url = upgradeUrl) {
 Usage limit reached. Opening upgrade page: ${url}
 `));
   try {
-    const openCommand =
-      process.platform === 'darwin'
-        ? { cmd: 'open', args: [url] }
-        : process.platform === 'win32'
-        ? { cmd: 'cmd', args: ['/c', 'start', '', url] }
-        : { cmd: 'xdg-open', args: [url] };
-    const opener = spawn(openCommand.cmd, openCommand.args, {
-      stdio: 'ignore',
-      detached: true,
-    });
-    opener.unref();
+    open(url).catch(() => {});
   } catch {}
 }
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   },
   "dependencies": {
     "boxen": "^7.1.1",
-    "chalk": "^5.3.0"
+    "chalk": "^5.3.0",
+    "open": "^11.0.0"
   },
   "files": [
     "mcp-server.js",


### PR DESCRIPTION
🎯 **What:** The command injection vulnerability in `mcp-server.js` was fixed.
⚠️ **Risk:** The previous implementation used `spawn('cmd', ['/c', 'start', '', url])` on Windows, which is vulnerable to command injection if malicious characters (like `&`, `|`, `"`) are included in the URL.
🛡️ **Solution:** Replaced the custom `spawn` logic with the industry-standard `open` package, which safely handles opening URLs and files across platforms, eliminating the command injection vector.

---
*PR created automatically by Jules for task [13489984866867059837](https://jules.google.com/task/13489984866867059837) started by @semihbugrasezer*