### PR TITLE
🧪 Implement unit tests for normalizeHost function

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -11,13 +11,13 @@ import { createRequire } from 'node:module';
 import { execSync, spawn } from 'node:child_process';
 import boxen from 'boxen';
 import chalk from 'chalk';
+import { DEFAULT_HOST, normalizeHost } from './utils.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('./package.json');
 
 const CONFIG_DIR = path.join(os.homedir(), '.seerxo-mcp');
 const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
-const DEFAULT_HOST = 'https://api.seerxo.com';
 const clientVersion = process.env.SEERXO_CLIENT_VERSION || pkg.version;
 const LOGIN_POLL_INTERVAL_MS = 4000;
 const LOGIN_TIMEOUT_MS = 15 * 60 * 1000;
@@ -71,10 +71,6 @@ const invokedAs = path.basename(invokedPath);
 const invokedAsMcp =
   invokedAs === 'seerxo-mcp' || invokedAs === 'etsy-seo-mcp' || invokedAs === 'seerxo';
 const invokedAsSeerxo = invokedAs === 'seerxo';
-
-function normalizeHost(value) {
-  return value ? value.replace(/\/$/, '') : DEFAULT_HOST;
-}
 
 function isSafeHttpUrl(value) {
   try {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "seerxo": "mcp-server.js"
   },
   "scripts": {
-    "start": "node mcp-server.js"
+    "start": "node mcp-server.js",
+    "test": "node --test"
   },
   "keywords": [
     "mcp",

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,5 @@
+export const DEFAULT_HOST = 'https://api.seerxo.com';
+
+export function normalizeHost(value) {
+  return value ? value.replace(/\/$/, '') : DEFAULT_HOST;
+}

--- a/utils.test.js
+++ b/utils.test.js
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { normalizeHost, DEFAULT_HOST } from './utils.js';
+
+test('normalizeHost', async (t) => {
+  await t.test('removes trailing slash', () => {
+    assert.strictEqual(normalizeHost('https://api.example.com/'), 'https://api.example.com');
+  });
+
+  await t.test('does not remove slash if not at the end', () => {
+    assert.strictEqual(normalizeHost('https://api.example.com/v1'), 'https://api.example.com/v1');
+  });
+
+  await t.test('returns value if no trailing slash', () => {
+    assert.strictEqual(normalizeHost('https://api.example.com'), 'https://api.example.com');
+  });
+
+  await t.test('returns DEFAULT_HOST for empty string', () => {
+    assert.strictEqual(normalizeHost(''), DEFAULT_HOST);
+  });
+
+  await t.test('returns DEFAULT_HOST for null', () => {
+    assert.strictEqual(normalizeHost(null), DEFAULT_HOST);
+  });
+
+  await t.test('returns DEFAULT_HOST for undefined', () => {
+    assert.strictEqual(normalizeHost(undefined), DEFAULT_HOST);
+  });
+});


### PR DESCRIPTION
This PR addresses the testing gap for the `normalizeHost` function.

🎯 **What:** The `normalizeHost` function was previously untested. It has been refactored into a separate `utils.js` module to allow for isolated unit testing without triggering the side effects in `mcp-server.js`.

📊 **Coverage:**
The following scenarios are now tested:
- Removal of trailing slashes from host URLs.
- Ensuring internal slashes are preserved.
- Correct handling of URLs already without trailing slashes.
- Defaulting to `DEFAULT_HOST` for empty, null, or undefined inputs.

✨ **Result:** Improved codebase reliability and a 100% test coverage for this utility function. The addition of a `test` script in `package.json` enables easy test execution for future development.

---
*PR created automatically by Jules for task [14507654815255414008](https://jules.google.com/task/14507654815255414008) started by @semihbugrasezer*