### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -71,7 +71,7 @@ function syncApiKeyState() {
 
 function printStatus() {
   const keyState = hasValidApiKey
-    ? `✔ configured (${apiKeyParts[0]})`
+    ? '✔ configured'
     : `✖ missing or invalid (expected keyId.secret with secret >= ${MIN_API_KEY_SECRET_LENGTH} chars)`;
 
   console.log(


### PR DESCRIPTION
Potential fix for [https://github.com/semihbugrasezer/etsy-seo-mcp/security/code-scanning/5](https://github.com/semihbugrasezer/etsy-seo-mcp/security/code-scanning/5)

To fix this without changing core behavior, update `printStatus()` so it no longer includes `apiKeyParts[0]` in output. Keep the configured/missing signal, but remove credential-derived detail.

**Best single fix:** in `mcp-server.js`, change `keyState` from:
- `✔ configured (${apiKeyParts[0]})`
to:
- `✔ configured`

This preserves user-visible status (configured vs invalid/missing) while eliminating sensitive clear-text logging. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
