### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -106,7 +106,7 @@ function syncApiKeyState() {
 
 function printStatus() {
   const keyState = hasValidApiKey
-    ? `✔ configured (${apiKeyParts[0]})`
+    ? '✔ configured'
     : `✖ missing or invalid (expected keyId.secret with secret >= ${MIN_API_KEY_SECRET_LENGTH} chars)`;
 
   console.log(


### PR DESCRIPTION
Potential fix for [https://github.com/semihbugrasezer/etsy-seo-mcp/security/code-scanning/5](https://github.com/semihbugrasezer/etsy-seo-mcp/security/code-scanning/5)

General fix approach: avoid logging raw or partially raw credential material; log only safe status indicators (e.g., “configured”) or masked forms.

Best fix here: in `mcp-server.js`, update `printStatus()` so `keyState` does not include `apiKeyParts[0]`. Keep behavior/functionality intact by still showing whether a key is configured and valid, but remove credential-derived identifier from output.

Specific change:
- In `printStatus()` (around lines 108–110), replace:
  - `✔ configured (${apiKeyParts[0]})`
  with:
  - `✔ configured`
- No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
