### PR TITLE
fix: Fix Windows MCP stdout issue and libuv crash

### DIFF
--- a/bin/seerxo-mcp.js
+++ b/bin/seerxo-mcp.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { initConfig, startMcpServer } from '../mcp-server.js';
+
+if (process.env.NODE_ENV !== 'test') {
+  initConfig()
+    .then(() => startMcpServer())
+    .catch((err) => {
+      console.error('[seerxo] Fatal error:', err);
+      process.exit(1);
+    });
+}

--- a/bin/seerxo.js
+++ b/bin/seerxo.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import { initConfig, startMcpServer, startInteractiveShell, handleCli } from '../mcp-server.js';
+
+async function main() {
+  await initConfig();
+
+  const args = process.argv.slice(2);
+
+  // Check if we should enter MCP mode directly
+  const isMcpMode = args.length === 0 && (!process.stdin.isTTY || !process.stdout.isTTY || process.env.SEERXO_MCP === '1');
+
+  if (isMcpMode) {
+    startMcpServer();
+    return;
+  }
+
+  if (args.length === 0) {
+    await startInteractiveShell();
+    return;
+  }
+
+  await handleCli(args);
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  main().catch((err) => {
+    console.error('[seerxo] Fatal error:', err);
+    process.exit(1);
+  });
+}

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -277,7 +277,7 @@ export function formatApiErrorMessage(message, status) {
   return normalizedMessage || 'Failed to generate Etsy SEO content';
 }
 
-async function initConfig() {
+export async function initConfig() {
   localConfig = await loadLocalConfigAsync();
 
   userEmail =
@@ -447,7 +447,8 @@ const runSelfUpdate = () => {
     if (error?.message) {
       console.error(`Error: ${error.message}`);
     }
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 };
 
@@ -473,12 +474,13 @@ const runConfigureCommand = async (extraArgs = [], options = {}) => {
       ).trim();
     }
   } finally {
-    rl.close();
+    if (!rl.closed) { rl.close(); rl.closed = true; };
   }
 
   if (!email) {
     console.error('Email is required.');
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   if (!resolveApiKeyState(apiKey).isValid) {
@@ -486,12 +488,14 @@ const runConfigureCommand = async (extraArgs = [], options = {}) => {
       console.error(
         'That value looks like a key ID only, not the full API key. Use the full "keyId.secret" value or run "seerxo login".'
       );
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
     console.error(
       `API key must be in the format "keyId.secret" and the secret part must be at least ${MIN_API_KEY_SECRET_LENGTH} characters.`
     );
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   await saveLocalConfigAsync({ email, apiKey, host });
@@ -613,7 +617,7 @@ const runLoginCommand = async (extraArgs = [], options = {}) => {
     throw new Error('Timed out waiting for approval. Please try again.');
   } catch (error) {
     console.error(error.message || 'CLI login failed.');
-    process.exit(1);
+    process.exitCode = 1; return;
   }
 };
 
@@ -777,7 +781,7 @@ function printSeoResult(productName, result) {
   );
 }
 
-async function startInteractiveShell() {
+export async function startInteractiveShell() {
   clearCliScreen();
   printCliBanner();
 
@@ -800,25 +804,25 @@ async function startInteractiveShell() {
       const cmd = line.startsWith('/') ? line.slice(1) : line;
 
       if (cmd === 'quit' || cmd === 'exit') {
-        rl.close();
+        if (!rl.closed) { rl.close(); rl.closed = true; };
         console.log('Bye 👋');
         return;
       }
 
       if (cmd === 'login') {
-        rl.close();
+        if (!rl.closed) { rl.close(); rl.closed = true; };
         await runLoginCommand([], { showBanner: false });
         return promptLoop();
       }
 
       if (cmd === 'logout' || cmd === 'signout' || cmd === 'sign-out') {
-        rl.close();
+        if (!rl.closed) { rl.close(); rl.closed = true; };
         await runLogoutCommand();
         return promptLoop();
       }
 
       if (cmd === 'configure') {
-        rl.close();
+        if (!rl.closed) { rl.close(); rl.closed = true; };
         await runConfigureCommand([], { showBanner: false });
         return promptLoop();
       }
@@ -914,38 +918,38 @@ async function startInteractiveShell() {
   await promptLoop();
 }
 
-async function handleCli(subArgs) {
+export async function handleCli(subArgs) {
   const sub = normalizeCommandName(subArgs[0]);
 
   if (!sub || sub === '--help' || sub === '-h') {
     printCliBanner();
     printUsage();
-    process.exit(0);
+    return;
   }
 
   if (sub === '--version' || sub === '-v') {
     console.log(clientVersion);
-    process.exit(0);
+    return;
   }
 
   if (sub === 'configure') {
     await runConfigureCommand(subArgs.slice(1));
-    process.exit(0);
+    return;
   }
 
   if (sub === 'login') {
     await runLoginCommand(subArgs.slice(1));
-    process.exit(0);
+    return;
   }
 
   if (sub === 'logout') {
     await runLogoutCommand();
-    process.exit(0);
+    return;
   }
 
   if (sub === 'status') {
     await printStatusWithQuota();
-    process.exit(0);
+    return;
   }
 
   if (sub === 'quota') {
@@ -954,9 +958,9 @@ async function handleCli(subArgs) {
       console.log(renderQuotaPanel(quota, { title: 'Live Credits' }));
     } catch (error) {
       console.error(error.message || 'Failed to load remaining credits');
-      process.exit(1);
+      process.exitCode = 1; return;
     }
-    process.exit(0);
+    return;
   }
 
   if (sub === 'generate') {
@@ -969,7 +973,8 @@ async function handleCli(subArgs) {
 
     if (productIndex === -1 || !subArgs[productIndex + 1]) {
       console.error('Missing argument: --product "Product name"');
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
     const productName = subArgs[productIndex + 1];
     const category =
@@ -1011,27 +1016,28 @@ async function handleCli(subArgs) {
       }
     } catch (error) {
       console.error(error.message || 'Content generation failed');
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
-    process.exit(0);
+    return;
   }
 
   if (sub === 'update' || sub === 'upgrade') {
     runSelfUpdate();
-    process.exit(0);
+    return;
   }
 
   console.error(`[seerxo] Unknown command: ${sub}`);
   printUsage();
-  process.exit(1);
+  process.exitCode = 1;
 }
 
-function startMcpServer() {
+export function startMcpServer() {
   if (!userEmail || !hasValidApiKey) {
     console.error(
       '[seerxo] Missing credentials. Run "seerxo login" or "seerxo configure" first.'
     );
-    process.exit(1);
+    process.exitCode = 1; return;
   }
 
   process.stdin.setEncoding('utf8');
@@ -1168,63 +1174,14 @@ function startMcpServer() {
   });
 
   process.stdin.on('end', () => {
-    process.exit(0);
+    return;
   });
 
   process.on('uncaughtException', (error) => {
     console.error('[seerxo] Uncaught error:', error);
-    process.exit(1);
+    process.exitCode = 1; return;
   });
 
   console.error('Seerxo MCP Server started');
 }
 
-async function main() {
-  await initConfig();
-
-  if (invokedAsSeerxo) {
-    if (args.length === 0) {
-      await startInteractiveShell();
-      return;
-    }
-    await handleCli(args);
-    return;
-  }
-
-  if (invokedAsMcp) {
-    const cliSubcommands = new Set([
-      'login',
-      'signin',
-      'sign-in',
-      'logout',
-      'signout',
-      'sign-out',
-      'configure',
-      'generate',
-      'status',
-      'quota',
-      'update',
-      'upgrade',
-      '--help',
-      '-h',
-      '--version',
-      '-v',
-    ]);
-    if (args.length > 0 && cliSubcommands.has(args[0])) {
-      await handleCli(args);
-      return;
-    }
-
-    startMcpServer();
-    return;
-  }
-
-  await handleCli(args);
-}
-
-if (process.env.NODE_ENV !== 'test') {
-  main().catch((err) => {
-    console.error('[seerxo] Fatal error:', err);
-    process.exit(1);
-  });
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
         "open": "^11.0.0"
       },
       "bin": {
-        "etsy-seo-mcp": "mcp-server.js",
-        "seerxo": "mcp-server.js",
-        "seerxo-mcp": "mcp-server.js"
+        "etsy-seo-mcp": "bin/seerxo-mcp.js",
+        "seerxo": "bin/seerxo.js",
+        "seerxo-mcp": "bin/seerxo-mcp.js"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "type": "module",
   "main": "mcp-server.js",
   "bin": {
-    "etsy-seo-mcp": "mcp-server.js",
-    "seerxo-mcp": "mcp-server.js",
-    "seerxo": "mcp-server.js"
+    "etsy-seo-mcp": "bin/seerxo-mcp.js",
+    "seerxo-mcp": "bin/seerxo-mcp.js",
+    "seerxo": "bin/seerxo.js"
   },
   "scripts": {
-    "start": "node mcp-server.js",
+    "start": "node bin/seerxo.js",
     "test": "echo \"No tests configured on main\"",
     "lint": "node --check mcp-server.js && node --check utils.js && node --check scripts/validate-package-files.mjs",
     "build": "node scripts/validate-package-files.mjs"
@@ -49,6 +49,8 @@
   },
   "files": [
     "mcp-server.js",
+    "bin/seerxo.js",
+    "bin/seerxo-mcp.js",
     "utils.js",
     "README.md",
     "LICENSE"


### PR DESCRIPTION
This PR solves two production issues reported by Windows users using the CLI and MCP client:

1. **MCP stdout Pollution Issue**:
   When clients like Claude Desktop launch `seerxo` or `seerxo-mcp`, they expect purely JSON-RPC stdout. Previously, the process printed CLI banners and UI hints which corrupted the JSON stream and resulted in "Unexpected token" errors on the client. 
   
   *Fix*: Extracted execution entries into dedicated `bin/seerxo.js` and `bin/seerxo-mcp.js` files. The main CLI now strictly inspects environment and stdio properties, dropping into the `startMcpServer()` immediately before initializing UI components if MCP mode is detected. `bin/seerxo-mcp.js` launches purely in MCP mode, acting as an isolated bridge.

2. **Windows libuv Assertion Crash**:
   Running synchronous commands like `seerxo quota` or `seerxo status` on Windows triggered `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)`. The root cause stems from the codebase using `process.exit(0)` synchronously alongside unhandled promises, leaving libuv resource handles forcefully destroyed before Node's garbage collector/cleanup could execute smoothly.
   
   *Fix*: Removed `process.exit(0)` calls in the normal execution flow to allow Node.js to shut down its event loop organically. Set `process.exitCode = 1; return;` appropriately on errors.

Furthermore, duplicate `rl.close()` events which could pollute the IO event stream are addressed by checking `!rl.closed` explicitly.

---
*PR created automatically by Jules for task [18240976750182961279](https://jules.google.com/task/18240976750182961279) started by @semihbugrasezer*