### PR TITLE
fix: grant release workflow publish permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      issues: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- add `id-token: write` so `@semantic-release/npm` can use GitHub OIDC/trusted publishing
- add `issues: write` so `@semantic-release/github` can report release failures instead of failing with a secondary 403

## Root cause
The release job failed in `@semantic-release/npm` verifyConditions because GitHub Actions did not expose `ACTIONS_ID_TOKEN_REQUEST_URL`. The log explicitly asks for `id-token: write`. After that failure, semantic-release also could not create its GitHub failure issue because the job token lacked `issues: write`.

## Verification
- `npm run lint`
- `npm run build`