### PR TITLE
fix: pass npm token to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,4 +43,5 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary
- pass `secrets.NPM_TOKEN` to `semantic-release` as `NPM_TOKEN`
- keeps OIDC trusted publishing support, but allows token-based npm auth when trusted publisher exchange fails

## Root cause
The latest release job has `id-token: write` and reaches npm OIDC exchange, but npm returns `404 OIDC token exchange error - package not found`. semantic-release then falls back to token auth and fails because `NPM_TOKEN` is not present in the step environment.

This workflow change fixes the missing env wiring. If the repository does not have an `NPM_TOKEN` secret configured, add one or complete npm trusted publisher setup for this package/workflow.

## Verification
- `npm run lint`
- `npm run build`