### PR TITLE
chore(deps): pin undici to patched versions via overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,12 @@
   },
   "overrides": {
     "ip-address": "10.1.1",
-    "npm": "11.17.0"
+    "npm": "11.17.0",
+    "@actions/http-client": {
+      "undici": "^6.27.0"
+    },
+    "@semantic-release/github": {
+      "undici": "^7.28.0"
+    }
   }
 }


### PR DESCRIPTION
## Ne
Dev araç zincirindeki transitive `undici`'yi, Set-Cookie / HTTP header-injection açıklarını kapatan sürümlere pinler:

| Override | undici |
|---|---|
| `@actions/http-client` | `^6.27.0` |
| `@semantic-release/github` | `^7.28.0` |

## Neden
`main`'in lockfile'ı zaten patched sürümleri çözüyor; bu override'lar **açık pin** olarak ileride lockfile'ın patched altına düşmesini (regresyon) engeller. Yalnızca `package.json` değişir, lockfile değişmez.

Kapsanan advisory'ler: GHSA-p88m-4jfj-68fv, GHSA-35p6-xmwp-9g52, GHSA-g8m3-5g58-fq7m.

## Kapsam dışı
Geriye kalan tek eşleşme, `npm` CLI'ın içine **bundle** edilmiş undici (`inBundle`, dev/CI-only, yayınlanan pakete dahil değil). Upstream fix henüz yok ve override'lar bundled dep'i değiştiremiyor → ilgili dependabot alert'leri `tolerable_risk` ile dismiss edildi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin transitive `undici` used by dev tooling to patched versions via `overrides` to close Set-Cookie/HTTP header-injection advisories and prevent lockfile regressions. Only `package.json` changes; no lockfile update.

- **Dependencies**
  - `@actions/http-client` → `undici@^6.27.0`
  - `@semantic-release/github` → `undici@^7.28.0`
  - Covers: GHSA-p88m-4jfj-68fv, GHSA-35p6-xmwp-9g52, GHSA-g8m3-5g58-fq7m
  - Remaining: `undici` bundled in `npm` CLI (dev/CI-only); cannot override; alerts dismissed as tolerable

<sup>Written for commit d6d853e8c229875e7b552d7994ea7fa0b04b8276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/etsy-seo-mcp/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

