### PR TITLE
feat: Claude Code skill — use Seerxo three ways (CLI · Skill · MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Generate perfect SEO titles, descriptions, and tags in seconds
 
 ## 🎯 What is this?
 
-A Claude Desktop integration that generates complete, SEO-optimized Etsy product listings instantly. Perfect for Etsy sellers who want to:
+A tool that generates complete, SEO-optimized Etsy product listings instantly. Use it **three ways from one package** — a **CLI**, a **Claude Code skill**, or an **MCP server** for Claude Desktop. Perfect for Etsy sellers who want to:
 
 - ✅ Save 3+ hours per product listing
 - ✅ Rank higher in Etsy search results
@@ -136,6 +136,37 @@ Generate an Etsy listing for my handmade ceramic coffee mug
 **Premium:** Unlimited generations - [Upgrade at seerxo.com](https://www.seerxo.com)
 
 > Note: The previous package `seerxo-mcp` is deprecated. Use `npm install -g seerxo`.
+
+### C) Claude Code Skill
+
+Add Seerxo as a [Claude Code](https://claude.com/claude-code) skill so you can ask for
+Etsy listings right inside Claude Code — it drives the CLI for you.
+
+```bash
+# install the CLI (once) and sign in
+npm install -g seerxo
+seerxo login
+
+# add the skill (user-level, all projects)
+seerxo skill add
+# …or scope it to the current repo only
+seerxo skill add --project
+```
+
+No global install needed? Run it straight from npx:
+
+```bash
+npx seerxo skill add
+```
+
+Then restart Claude Code and ask:
+
+```
+Generate an Etsy listing for my handmade ceramic coffee mug
+```
+
+Remove it anytime with `seerxo skill remove` (add `--project` for the repo-scoped copy).
+The skill installs to `~/.claude/skills/seerxo-etsy-seo/` (or `./.claude/skills/…` with `--project`).
 
 ---
 

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -368,6 +368,7 @@ const printUsage = () => {
       `  seerxo configure [--email you@example.com --api-key keyId.secret --host https://api.seerxo.com]\n` +
       `  seerxo quota        # show remaining credits\n` +
       `  seerxo generate --product \"...\" [--category \"...\"] [--json]\n` +
+      `  seerxo skill add|remove|path [--project]   # Claude Code skill\n` +
       `  seerxo update|upgrade   # update CLI to latest\n` +
       `  seerxo --help           # show this message\n` +
       `  seerxo --version        # show version\n\n` +
@@ -420,6 +421,66 @@ const printCliBanner = () => {
       width,
     })
   );
+};
+
+const SKILL_NAME = 'seerxo-etsy-seo';
+const bundledSkillUrl = new URL('./skills/seerxo-etsy-seo/SKILL.md', import.meta.url);
+
+const skillTargetDir = (projectScope) =>
+  projectScope
+    ? path.join(process.cwd(), '.claude', 'skills', SKILL_NAME)
+    : path.join(os.homedir(), '.claude', 'skills', SKILL_NAME);
+
+const printSkillUsage = () => {
+  console.log(
+    'Usage:\n' +
+      '  seerxo skill add [--project]      # install the Claude Code skill\n' +
+      '  seerxo skill remove [--project]   # remove it\n' +
+      '  seerxo skill path [--project]     # print the install path\n\n' +
+      'Default scope is your user config (~/.claude/skills). Use --project for the current repo.'
+  );
+};
+
+const runSkillCommand = async (extraArgs = []) => {
+  const action = normalizeCommandName(extraArgs[0]) || 'add';
+  const projectScope = extraArgs.includes('--project');
+  const targetDir = skillTargetDir(projectScope);
+  const targetPath = path.join(targetDir, 'SKILL.md');
+  const scopeLabel = projectScope ? 'project (.claude/skills)' : 'user (~/.claude/skills)';
+
+  if (action === 'path') {
+    console.log(targetPath);
+    return;
+  }
+
+  if (action === 'remove' || action === 'rm' || action === 'uninstall') {
+    try {
+      await fsPromises.rm(targetDir, { recursive: true, force: true });
+      console.log(`Removed Seerxo skill from ${scopeLabel}.`);
+    } catch (error) {
+      console.error(`Failed to remove skill: ${error.message}`);
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  if (action === 'add' || action === 'install') {
+    try {
+      const contents = await fsPromises.readFile(bundledSkillUrl, 'utf8');
+      await fsPromises.mkdir(targetDir, { recursive: true });
+      await fsPromises.writeFile(targetPath, contents, 'utf8');
+      console.log(`Installed Seerxo Etsy SEO skill to ${scopeLabel}.`);
+      console.log(`  ${targetPath}`);
+      console.log('Restart Claude Code, then ask: "Generate an Etsy listing for ...".');
+      console.log('Tip: run "seerxo login" once so the skill can generate on your account.');
+    } catch (error) {
+      console.error(`Failed to install skill: ${error.message}`);
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  printSkillUsage();
 };
 
 const runSelfUpdate = () => {
@@ -1019,6 +1080,11 @@ export async function handleCli(subArgs) {
       process.exitCode = 1;
       return;
     }
+    return;
+  }
+
+  if (sub === 'skill') {
+    await runSkillCommand(subArgs.slice(1));
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "mcp",
     "model-context-protocol",
     "claude-desktop",
+    "claude-code",
+    "claude-skill",
+    "cli",
     "etsy",
     "etsy-seo",
     "seo",
@@ -51,6 +54,7 @@
     "mcp-server.js",
     "bin/seerxo.js",
     "bin/seerxo-mcp.js",
+    "skills/seerxo-etsy-seo/SKILL.md",
     "utils.js",
     "README.md",
     "LICENSE"

--- a/skills/seerxo-etsy-seo/SKILL.md
+++ b/skills/seerxo-etsy-seo/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: seerxo-etsy-seo
+description: Generate SEO-optimized Etsy listings — title, description, 13 tags, and a suggested price range — using the Seerxo CLI. Use whenever the user wants Etsy SEO, an Etsy product listing, product tags, or a title/description for something they sell on Etsy.
+---
+
+# Seerxo · Etsy SEO
+
+Produce a complete, Etsy-ready listing (title, description, 13 tags, suggested price)
+from a short product description by calling the Seerxo CLI. Do not hand-write listings —
+always call the CLI so output stays on-quota and consistent with the Seerxo web app,
+dashboard, and MCP server (they all share the same credits).
+
+## When to use
+
+Trigger when the user asks for any of: an Etsy listing, Etsy SEO, a product title,
+a product description, or Etsy tags for something they sell.
+
+## How to generate
+
+Run the Seerxo CLI and parse its JSON output:
+
+```bash
+seerxo generate --product "<short product description>" --category "<optional category>" --json
+```
+
+- `--product` (required): a short natural description, e.g.
+  `"handmade ceramic coffee mug, speckled glaze, 12oz"`.
+- `--category` (optional): the Etsy category, e.g. `"Home & Living"`. Ask for it only if it helps.
+- `--json` (required here): returns structured JSON to format.
+
+The command prints JSON shaped like:
+
+```json
+{
+  "title": "…",
+  "description": "…",
+  "tags": ["…", "…"],
+  "suggested_price_range": "$28-$45",
+  "usage": { "current": 3, "limit": 300, "remaining": 297 }
+}
+```
+
+Present it back as: the title (under 140 chars, the Etsy limit), the description, the
+13 tags (as a list or comma-separated), and the suggested price. Mention remaining
+credits from `usage` when present.
+
+## If the CLI is missing or not signed in
+
+- **Not installed** (`command not found: seerxo`): tell the user to run `npm install -g seerxo`.
+- **Credential errors** ("Email is not set" / "Invalid API key" / "Run seerxo login"):
+  tell the user to run `seerxo login` (opens a browser to sign in with Google), then retry.
+- **Quota reached**: the free tier allows 5 generations/month — point them to
+  https://www.seerxo.com to upgrade to Premium (up to 300/month).
+
+## Notes
+
+- One generation per product request.
+- Keep the user's wording; pass their description through to `--product` rather than rewriting it.


### PR DESCRIPTION
Adds a **Claude Code skill** so Seerxo can be used three ways from one package: **CLI**, **Skill**, and **MCP** server.

## What's new
- `skills/seerxo-etsy-seo/SKILL.md` — a Claude Code skill that drives `seerxo generate --json` (same auth/quota/billing as CLI, MCP, and web).
- `seerxo skill` subcommand:
  - `seerxo skill add [--project]` → install to `~/.claude/skills/seerxo-etsy-seo/` (or `./.claude/skills/…`)
  - `seerxo skill remove [--project]`
  - `seerxo skill path [--project]`
- Works via `npx seerxo skill add`.
- Ships `SKILL.md` in `package.files`; README documents the new path; added `claude-code` / `claude-skill` / `cli` keywords.

## Verification
- `npm run lint` (node --check) ✓
- `npm run build` (package-files validator) ✓
- Manually exercised `skill add` / `--project` / `remove` / `path` / bad-action usage against a temp `HOME` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Claude Code skill and a `seerxo skill` subcommand so Seerxo works three ways from one package: CLI, Claude Code skill, and MCP server. The skill calls `seerxo generate --json`, sharing the same login, quota, and billing across all entry points.

- **New Features**
  - Bundle `skills/seerxo-etsy-seo/SKILL.md` that drives the CLI for Etsy SEO.
  - New CLI: `seerxo skill add|remove|path [--project]`; installs to `~/.claude/skills/seerxo-etsy-seo/` or `./.claude/skills/…`.
  - Supports `npx seerxo skill add`; ship `SKILL.md` in `package.files` and add `claude-code`/`claude-skill`/`cli` keywords.
  - README updated with skill setup and usage.

<sup>Written for commit 1ab28a67e2510dffaa8889fcfeb571228075b831. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/etsy-seo-mcp/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

