### PR TITLE
fix: drop suggested price; correct README/skill to real features

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GitHub](https://img.shields.io/github/stars/semihbugrasezer/etsy-seo-mcp?style=social)](https://github.com/semihbugrasezer/etsy-seo-mcp)
 
-**AI-powered Etsy product listing generator for Claude Desktop**
+**AI-powered Etsy listing generator — CLI, Claude Code skill, or MCP server**
 
-Generate perfect SEO titles, descriptions, and tags in seconds
+Generate SEO-optimized titles, descriptions, and 13 tags in seconds
 
 [Live Demo](https://www.seerxo.com) • [Quick Start](#-quick-start) • [Examples](#-examples)
 
@@ -133,7 +133,7 @@ Generate an Etsy listing for my handmade ceramic coffee mug
 ```
 
 **Free Tier:** 5 generations per month
-**Premium:** Unlimited generations - [Upgrade at seerxo.com](https://www.seerxo.com)
+**Premium:** Up to 300 generations per month - [Upgrade at seerxo.com](https://www.seerxo.com)
 
 > Note: The previous package `seerxo-mcp` is deprecated. Use `npm install -g seerxo`.
 
@@ -210,10 +210,6 @@ Each generation includes:
 - Etsy search-optimized
 - Trending search terms included
 
-### 💰 Price Suggestion
-- Based on similar Etsy products
-- Market competitive range
-
 ---
 
 
@@ -259,9 +255,6 @@ birthday gift.
 handmade mug, ceramic coffee cup, pottery mug, artisan mug, unique gift,
 coffee lover gift, handcrafted, kitchen decor, tea cup, housewarming gift,
 birthday present, ceramic pottery, handmade gift
-
-💰 SUGGESTED PRICE
-$28-$45
 ```
 
 ---

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -828,9 +828,6 @@ function printSeoResult(productName, result) {
         '',
         chalk.bold('Tags:'),
         result.tags.join(', '),
-        '',
-        chalk.bold('Suggested Price:'),
-        result.suggested_price_range,
       ].join('\n'),
       {
         padding: 1,
@@ -1062,9 +1059,6 @@ export async function handleCli(subArgs) {
               '',
               chalk.bold('Tags:'),
               result.tags.join(', '),
-              '',
-              chalk.bold('Suggested Price:'),
-              result.suggested_price_range,
             ].join('\n'),
             {
               padding: 1,
@@ -1200,11 +1194,9 @@ export function startMcpServer() {
                 content: [
                   {
                     type: 'text',
-                    text: `# Etsy SEO Results for "${toolArgs.product_name}"\n\n## 📝 SEO Title\n${result.title}\n\n## 📄 Product Description\n${result.description}\n\n## 🏷️ Tags (15)\n${result.tags.join(
+                    text: `# Etsy SEO Results for "${toolArgs.product_name}"\n\n## 📝 SEO Title\n${result.title}\n\n## 📄 Product Description\n${result.description}\n\n## 🏷️ Tags (13)\n${result.tags.join(
                       ', '
-                    )}\n\n## 💰 Suggested Price\n${
-                      result.suggested_price_range
-                    }${usageInfo}`,
+                    )}${usageInfo}`,
                   },
                 ],
               },

--- a/skills/seerxo-etsy-seo/SKILL.md
+++ b/skills/seerxo-etsy-seo/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: seerxo-etsy-seo
-description: Generate SEO-optimized Etsy listings — title, description, 13 tags, and a suggested price range — using the Seerxo CLI. Use whenever the user wants Etsy SEO, an Etsy product listing, product tags, or a title/description for something they sell on Etsy.
+description: Generate SEO-optimized Etsy listings — title, description, and 13 tags — using the Seerxo CLI. Use whenever the user wants Etsy SEO, an Etsy product listing, product tags, or a title/description for something they sell on Etsy.
 ---
 
 # Seerxo · Etsy SEO
 
-Produce a complete, Etsy-ready listing (title, description, 13 tags, suggested price)
+Produce a complete, Etsy-ready listing (title, description, and 13 tags)
 from a short product description by calling the Seerxo CLI. Do not hand-write listings —
 always call the CLI so output stays on-quota and consistent with the Seerxo web app,
 dashboard, and MCP server (they all share the same credits).
@@ -33,16 +33,19 @@ The command prints JSON shaped like:
 ```json
 {
   "title": "…",
+  "title_alternatives": ["…", "…"],
   "description": "…",
   "tags": ["…", "…"],
-  "suggested_price_range": "$28-$45",
+  "features": ["…"],
+  "target_keywords": ["…"],
+  "suggested_attributes": { "occasion": "…", "style": "…", "color": "…", "material": "…", "recipient": "…" },
   "usage": { "current": 3, "limit": 300, "remaining": 297 }
 }
 ```
 
-Present it back as: the title (under 140 chars, the Etsy limit), the description, the
-13 tags (as a list or comma-separated), and the suggested price. Mention remaining
-credits from `usage` when present.
+Present the title (under 140 chars, the Etsy limit), the description, and the 13 tags
+(as a list or comma-separated). Surface `title_alternatives` and `suggested_attributes`
+only if the user asks. Mention remaining credits from `usage` when present.
 
 ## If the CLI is missing or not signed in
 


### PR DESCRIPTION
Verifies docs against the real code and removes inaccurate / dead info.

- **Suggested price removed** from CLI output, MCP tool output, and the skill (the API stopped returning it).
- **README accuracy:** Premium is *up to 300/mo* (was wrongly 'Unlimited'); MCP tag header said *15* → now *13*; tagline reflects CLI / Claude Code skill / MCP.
- **Skill:** JSON sample now matches the real response shape; leaner presentation guidance.

Verified: `npm run build` (package validator) ✓ · `seerxo skill add` smoke test ✓ (installed skill has zero price refs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the obsolete Suggested Price from the `seerxo` CLI, MCP server output, and the `seerxo-etsy-seo` skill to match the current API. Updated docs to reflect real behavior: Premium is up to 300/mo, 13 tags (not 15), refreshed tagline, and aligned the skill JSON/sample and guidance with actual fields (`title_alternatives`, `features`, `target_keywords`, `suggested_attributes`, `usage`).

<sup>Written for commit 6df3bb74ab7ffa72a735756b9c6b26506e1c16bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/etsy-seo-mcp/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

