### PR TITLE
feat(skill): copy-paste-ready Etsy output + full value surfaced

### DIFF
--- a/skills/seerxo-etsy-seo/SKILL.md
+++ b/skills/seerxo-etsy-seo/SKILL.md
@@ -1,34 +1,34 @@
 ---
 name: seerxo-etsy-seo
-description: Generate SEO-optimized Etsy listings — title, description, and 13 tags — using the Seerxo CLI. Use whenever the user wants Etsy SEO, an Etsy product listing, product tags, or a title/description for something they sell on Etsy.
+description: Generate or optimize a complete, copy-paste-ready Etsy listing — front-loaded title (+ A/B variants), hook-first description, 13 search-optimized tags, and the Etsy listing attributes to set — by calling the Seerxo CLI. Use whenever the user wants Etsy SEO, an Etsy listing, product tags, a title/description, or wants to improve/rank an existing Etsy listing.
 ---
 
 # Seerxo · Etsy SEO
 
-Produce a complete, Etsy-ready listing (title, description, and 13 tags)
-from a short product description by calling the Seerxo CLI. Do not hand-write listings —
-always call the CLI so output stays on-quota and consistent with the Seerxo web app,
-dashboard, and MCP server (they all share the same credits).
+One CLI call turns a short product description into a complete, copy-paste-ready Etsy
+listing. Always call the CLI — never hand-write the listing — so output stays on-quota
+and consistent with the Seerxo web app, dashboard, and MCP server (they share credits).
 
 ## When to use
 
-Trigger when the user asks for any of: an Etsy listing, Etsy SEO, a product title,
-a product description, or Etsy tags for something they sell.
+Trigger when the user wants any of: an Etsy listing, Etsy SEO, a product title, a
+product description, Etsy tags, or to optimize / rank-up an existing Etsy listing.
 
-## How to generate
+## Generate
 
-Run the Seerxo CLI and parse its JSON output:
+1. Build the product phrase from the user's own words — keep their wording, don't rewrite it.
+2. Infer an Etsy `--category` only when it's obvious, to sharpen keyword matching:
+   mug/candle/decor → `"Home & Living"`, necklace/ring → `"Jewelry"`, shirt/hoodie →
+   `"Clothing"`, sticker → `"Craft Supplies"`, card/print → `"Paper & Party Supplies"`,
+   bridesmaid/wedding → `"Weddings"`, dog/cat item → `"Pet Supplies"`, baby item →
+   `"Baby"`. Skip `--category` if unsure.
+3. Run (wrap each value in double quotes; escape any inner `"` as `\"`):
 
 ```bash
-seerxo generate --product "<short product description>" --category "<optional category>" --json
+seerxo generate --product "handmade ceramic coffee mug, speckled glaze, 12oz" --category "Home & Living" --json
 ```
 
-- `--product` (required): a short natural description, e.g.
-  `"handmade ceramic coffee mug, speckled glaze, 12oz"`.
-- `--category` (optional): the Etsy category, e.g. `"Home & Living"`. Ask for it only if it helps.
-- `--json` (required here): returns structured JSON to format.
-
-The command prints JSON shaped like:
+Always pass `--json` and parse the result. Shape:
 
 ```json
 {
@@ -43,19 +43,34 @@ The command prints JSON shaped like:
 }
 ```
 
-Present the title (under 140 chars, the Etsy limit), the description, and the 13 tags
-(as a list or comma-separated). Surface `title_alternatives` and `suggested_attributes`
-only if the user asks. Mention remaining credits from `usage` when present.
+## Present it — copy-paste ready
 
-## If the CLI is missing or not signed in
+Format the result so the seller can paste each block straight into Etsy. Use these
+exact labels and keep it scannable:
 
-- **Not installed** (`command not found: seerxo`): tell the user to run `npm install -g seerxo`.
-- **Credential errors** ("Email is not set" / "Invalid API key" / "Run seerxo login"):
-  tell the user to run `seerxo login` (opens a browser to sign in with Google), then retry.
-- **Quota reached**: the free tier allows 5 generations/month — point them to
-  https://www.seerxo.com to upgrade to Premium (up to 300/month).
+- **Title** — `title` on a single line (it is already ≤140 chars, the Etsy limit).
+- **Alt titles (A/B)** — list `title_alternatives` when present, for split-testing.
+- **Tags (13)** — output as ONE comma-separated line (this is exactly what Etsy's tag
+  box accepts), then a short note confirming "13 tags, each ≤20 chars."
+- **Description** — the full `description`, ready to paste.
+- **Etsy attributes** — when present, list `suggested_attributes` as `Field: value`
+  (Occasion, Style, Color, Material, Recipient) so the seller can fill Etsy's attribute
+  dropdowns — these boost filter visibility.
+- **Targets** — when present, list `target_keywords` (what the listing is built to rank for).
+- **Credits** — from `usage`, say "X of Y generations left this month."
 
-## Notes
+Ship exactly what the CLI returned — do not add, drop, or rewrite tags yourself. The CLI
+already enforces 13 tags, ≤20 chars, lowercase, and no duplicates; trust its output.
 
-- One generation per product request.
-- Keep the user's wording; pass their description through to `--product` rather than rewriting it.
+## Errors → the exact fix
+
+- `command not found: seerxo` → tell the user to run `npm install -g seerxo`.
+- "Email is not set" / "Invalid API key" / "Run seerxo login" → run `seerxo login`
+  (opens a browser for Google sign-in), then retry. To inspect state: `seerxo status`.
+- "Monthly quota exceeded" → the account is out of credits; upgrade at
+  https://www.seerxo.com (Free = 5/month, Premium = up to 300/month).
+
+## Multiple products
+
+If the user lists several products, run one `seerxo generate` per product and present
+each listing under its own heading. One generation = one credit.


### PR DESCRIPTION
Makes the Claude Code skill genuinely useful instead of a thin wrapper:
- **Copy-paste-ready output**: title, A/B title variants, **13 tags as one comma-separated line** (Etsy's tag box format), description, **Etsy listing attributes** (occasion/style/color/material/recipient), target keywords, and remaining credits.
- **Category inference** to sharpen keyword matching.
- **Exact fix commands** for not-installed / not-signed-in / quota errors.
- **Multiple products** batched, one credit each.

Verified: package validator ✓ · `seerxo skill add` smoke test ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the `seerxo-etsy-seo` skill produce a complete, copy-paste-ready Etsy listing and surface all key fields. Adds category inference, exact fix commands for common CLI errors, and batching for multiple products.

- **New Features**
  - Copy-paste blocks: Title, A/B title variants, 13 Tags as one comma-separated line, Description, Etsy attributes, Target keywords, Credits.
  - Category inference (only when obvious) to sharpen keyword matching.
  - Exact fix commands for install, login, and quota errors (`npm install -g seerxo`, `seerxo login`, upgrade link).
  - Batch support: run `seerxo generate` once per product; present each result separately.
  - Clear JSON parsing and output rules via `--json`; keep user wording and trust CLI constraints.

<sup>Written for commit 45b3ee1f244faaab947a097ce57f541f1d57e88f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/etsy-seo-mcp/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

