### PR TITLE
feat(mcp): listing audit + optimize tools (seerxo_analyze_listing, seerxo_optimize_listing)

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -787,6 +787,120 @@ async function generateEtsySEO(productName, category = '') {
   return result;
 }
 
+// Shared caller for the versioned REST API (/v1/*) — same HMAC scheme as
+// /mcp/generate. The response contracts live server-side; tools wrap them 1:1.
+async function callSeerxoV1(pathname, payload) {
+  if (!apiKeyHeader || !apiKeySecret) {
+    throw new Error('API key is not set. Run "seerxo configure" first.');
+  }
+
+  const { signature, timestamp } = generateSignature(payload);
+  try {
+    const data = await fetchJson(`${apiHost}${pathname}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': `seerxo/${clientVersion}`,
+        'X-MCP-Signature': signature,
+        'X-MCP-Timestamp': timestamp.toString(),
+        'X-MCP-Version': clientVersion,
+        'X-MCP-API-Key': apiKeyHeader,
+      },
+      body: JSON.stringify(payload),
+    });
+    if (!data.success) {
+      throw new Error(data.error || 'Request failed');
+    }
+    return data.data;
+  } catch (error) {
+    throw new Error(formatApiErrorMessage(error.message, error.status), { cause: error });
+  }
+}
+
+// Map MCP tool arguments onto the /v1 audit request body.
+export function buildListingPayload(toolArgs = {}) {
+  const payload = {};
+  if (toolArgs.product_name) payload.productName = toolArgs.product_name;
+  if (toolArgs.title) payload.title = toolArgs.title;
+  if (toolArgs.description) payload.description = toolArgs.description;
+  if (Array.isArray(toolArgs.tags)) payload.tags = toolArgs.tags;
+  if (toolArgs.url) payload.url = toolArgs.url;
+  return payload;
+}
+
+const LISTING_INPUT_PROPERTIES = {
+  title: { type: 'string', description: 'The listing title, exactly as it appears on Etsy.' },
+  description: { type: 'string', description: 'The listing description.' },
+  tags: {
+    type: 'array',
+    items: { type: 'string' },
+    description: 'The listing tags (up to 13).',
+  },
+  product_name: {
+    type: 'string',
+    description: 'What the product is (e.g. "handmade ceramic coffee mug"). Improves keyword-coverage checks.',
+  },
+  url: {
+    type: 'string',
+    description:
+      'Optional Etsy listing URL. A URL alone is NOT enough — Etsy blocks server-side fetching, so always pass the listing fields you can see. The URL adds the product name from its slug.',
+  },
+};
+
+export const LISTING_TOOLS = [
+  {
+    name: 'seerxo_analyze_listing',
+    description:
+      'Audit an existing Etsy listing. Returns an SEO score (0-100) with per-field sub-scores, ranked weak points (each with severity and a concrete fix), missing keywords, and tag-slot utilization. Call it with whatever listing fields are available (title, tags, description); at least one is required.',
+    inputSchema: { type: 'object', properties: LISTING_INPUT_PROPERTIES, required: [] },
+  },
+  {
+    name: 'seerxo_optimize_listing',
+    description:
+      'Rewrite an Etsy listing to fix its audit findings: improved title, description, and tag set, each mapped to the finding it resolves, with a before/after SEO score. Etsy limits (140-char title, 13 tags, 20 chars per tag) are enforced server-side and the result never scores below the original. Provide the current listing fields.',
+    inputSchema: { type: 'object', properties: LISTING_INPUT_PROPERTIES, required: [] },
+  },
+];
+
+export function formatAnalyzeResult(data) {
+  const s = data.subScores || {};
+  const weakPoints = (data.weakPoints || [])
+    .map((wp, i) => `${i + 1}. [${wp.severity}] (${wp.field}) ${wp.reason} — fix: ${wp.fix}`)
+    .join('\n');
+  const util = data.tagUtilization || {};
+  const utilNotes = [
+    util.duplicates?.length ? `duplicates: ${util.duplicates.join(', ')}` : '',
+    util.overLong?.length ? `over 20 chars: ${util.overLong.join(', ')}` : '',
+    util.tooBroad?.length ? `single-word (too broad): ${util.tooBroad.join(', ')}` : '',
+  ].filter(Boolean).join(' · ');
+
+  return (
+    `# Listing Audit\n\n` +
+    `**SEO Score: ${data.seoScore}/100** — title ${s.title}, tags ${s.tags}, description ${s.description}, completeness ${s.completeness}\n\n` +
+    `## Weak points\n${weakPoints || 'None — this listing passes every check.'}\n\n` +
+    `## Missing keywords\n${(data.missingKeywords || []).join(', ') || 'none'}\n\n` +
+    `## Tag slots\n${util.used}/${util.max} used${utilNotes ? ` (${utilNotes})` : ''}`
+  );
+}
+
+export function formatOptimizeResult(data) {
+  const before = data.before || {};
+  const after = data.after || {};
+  const optimized = data.optimized || {};
+  const fallbackNote = data.fallback
+    ? '\n\n> Note: the rewrite did not beat the original listing, so the original fields were kept.'
+    : '';
+
+  return (
+    `# Optimized Listing\n\n` +
+    `**SEO Score: ${before.seoScore} → ${after.seoScore}** · resolved ${data.resolved?.length ?? 0} finding(s)` +
+    `${data.unresolved?.length ? `, still open: ${data.unresolved.join(', ')}` : ''}${fallbackNote}\n\n` +
+    `## Title\n${optimized.title}\n\n` +
+    `## Description\n${optimized.description}\n\n` +
+    `## Tags (${(optimized.tags || []).length})\n${(optimized.tags || []).join(', ')}`
+  );
+}
+
 async function promptLoginIfNecessary() {
   if (!userEmail || !hasValidApiKey) {
     const rlLogin = readline.createInterface({ input, output });
@@ -1166,6 +1280,7 @@ export function startMcpServer() {
                     required: ['product_name'],
                   },
                 },
+                ...LISTING_TOOLS,
               ],
             },
           };
@@ -1197,6 +1312,27 @@ export function startMcpServer() {
                     text: `# Etsy SEO Results for "${toolArgs.product_name}"\n\n## 📝 SEO Title\n${result.title}\n\n## 📄 Product Description\n${result.description}\n\n## 🏷️ Tags (13)\n${result.tags.join(
                       ', '
                     )}${usageInfo}`,
+                  },
+                ],
+              },
+            };
+
+            console.log(JSON.stringify(response));
+          } else if (name === 'seerxo_analyze_listing' || name === 'seerxo_optimize_listing') {
+            const isAnalyze = name === 'seerxo_analyze_listing';
+            const data = await callSeerxoV1(
+              isAnalyze ? '/v1/analyze' : '/v1/optimize',
+              buildListingPayload(toolArgs)
+            );
+
+            const response = {
+              jsonrpc: '2.0',
+              id: request.id,
+              result: {
+                content: [
+                  {
+                    type: 'text',
+                    text: isAnalyze ? formatAnalyzeResult(data) : formatOptimizeResult(data),
                   },
                 ],
               },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "node bin/seerxo.js",
-    "test": "NODE_ENV=test node --test tests/",
+    "test": "NODE_ENV=test node --test",
     "lint": "node --check mcp-server.js && node --check utils.js && node --check scripts/validate-package-files.mjs",
     "build": "node scripts/validate-package-files.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "node bin/seerxo.js",
-    "test": "echo \"No tests configured on main\"",
+    "test": "NODE_ENV=test node --test tests/",
     "lint": "node --check mcp-server.js && node --check utils.js && node --check scripts/validate-package-files.mjs",
     "build": "node scripts/validate-package-files.mjs"
   },

--- a/tests/listing-tools.test.js
+++ b/tests/listing-tools.test.js
@@ -1,0 +1,97 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  LISTING_TOOLS,
+  buildListingPayload,
+  formatAnalyzeResult,
+  formatOptimizeResult,
+} from '../mcp-server.js';
+
+describe('listing tool definitions', () => {
+  it('exposes both tools with agent-usable schemas', () => {
+    const names = LISTING_TOOLS.map((t) => t.name);
+    assert.deepStrictEqual(names, ['seerxo_analyze_listing', 'seerxo_optimize_listing']);
+    for (const tool of LISTING_TOOLS) {
+      assert.ok(tool.description.length > 50, 'description should tell the agent when/how to call');
+      assert.strictEqual(tool.inputSchema.type, 'object');
+      for (const key of ['title', 'description', 'tags', 'product_name', 'url']) {
+        assert.ok(tool.inputSchema.properties[key], `missing schema property ${key}`);
+      }
+    }
+  });
+});
+
+describe('buildListingPayload', () => {
+  it('maps tool args onto the /v1 request body', () => {
+    assert.deepStrictEqual(
+      buildListingPayload({
+        product_name: 'ceramic mug',
+        title: 'T',
+        description: 'D',
+        tags: ['a', 'b'],
+        url: 'https://www.etsy.com/listing/1/x',
+        junk: 'dropped',
+      }),
+      {
+        productName: 'ceramic mug',
+        title: 'T',
+        description: 'D',
+        tags: ['a', 'b'],
+        url: 'https://www.etsy.com/listing/1/x',
+      }
+    );
+  });
+
+  it('omits missing fields instead of sending empties', () => {
+    assert.deepStrictEqual(buildListingPayload({ title: 'T', tags: 'not-array' }), { title: 'T' });
+  });
+});
+
+describe('formatters', () => {
+  const audit = {
+    seoScore: 62,
+    subScores: { title: 80, tags: 40, description: 100, completeness: 66 },
+    weakPoints: [
+      { id: 'tags_count', field: 'tags', severity: 'high', reason: 'Exactly 13 tags', fix: 'Use all 13 tag slots.' },
+    ],
+    missingKeywords: ['12oz'],
+    tagUtilization: { used: 7, max: 13, duplicates: ['mug'], tooBroad: ['mug'], overLong: [] },
+  };
+
+  it('renders an audit as readable markdown with score, fixes, and tag slots', () => {
+    const text = formatAnalyzeResult(audit);
+    assert.ok(text.includes('62/100'));
+    assert.ok(text.includes('[high] (tags) Exactly 13 tags — fix: Use all 13 tag slots.'));
+    assert.ok(text.includes('12oz'));
+    assert.ok(text.includes('7/13 used'));
+    assert.ok(text.includes('duplicates: mug'));
+  });
+
+  it('renders an optimize result with before/after and the rewritten fields', () => {
+    const text = formatOptimizeResult({
+      before: { seoScore: 40 },
+      after: { seoScore: 95 },
+      optimized: { title: 'New Title', description: 'New description.', tags: ['a b', 'c d'] },
+      resolved: ['tags_count', 'desc_present'],
+      unresolved: ['tags_multiword'],
+      fallback: false,
+    });
+    assert.ok(text.includes('40 → 95'));
+    assert.ok(text.includes('resolved 2 finding(s)'));
+    assert.ok(text.includes('still open: tags_multiword'));
+    assert.ok(text.includes('New Title'));
+    assert.ok(text.includes('a b, c d'));
+  });
+
+  it('flags the fallback case honestly', () => {
+    const text = formatOptimizeResult({
+      before: { seoScore: 90 },
+      after: { seoScore: 90 },
+      optimized: { title: 't', description: 'd', tags: [] },
+      resolved: [],
+      unresolved: [],
+      fallback: true,
+    });
+    assert.ok(text.includes('original fields were kept'));
+  });
+});


### PR DESCRIPTION
## Summary
- Two new MCP tools wrapping the backend's versioned API 1:1 (PRD R5): **`seerxo_analyze_listing`** (`POST /v1/analyze`) and **`seerxo_optimize_listing`** (`POST /v1/optimize`), alongside the existing `generate_etsy_seo`.
- Shared `callSeerxoV1` helper reuses the existing HMAC signing and error formatting; no new auth code.
- Tool descriptions written for agents: what comes back, that at least one listing field is required, and that a bare Etsy URL is not enough (Etsy blocks server-side fetches).
- Results render as compact markdown: SEO score + sub-scores, severity-ranked weak points with fixes, missing keywords, tag-slot utilization; optimize shows before→after score, resolved finding ids, and the rewritten fields.
- Adds `tests/listing-tools.test.js` and wires `npm test` (CI already runs it via `--if-present`).

## Test plan
- `npm test` → 6/6 pass; `npm run lint` clean.
- End-to-end stdio smoke: spawned the real MCP binary against a locally running backend (in-memory Firestore, real HMAC) — `initialize` ✓, `tools/list` returns 3 tools ✓, analyze returned 46/100 with ranked weak points ✓, optimize returned 46→100 resolving 9 findings ✓.

Depends on semihbugrasezer/seerxo-backend#48 being deployed for production use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two MCP tools to audit and optimize Etsy listings via the backend’s versioned API, with compact markdown results and no new auth paths. Agents can score listings, see ranked fixes, and safely auto-rewrite titles, descriptions, and tags.

- **New Features**
  - Added `seerxo_analyze_listing` and `seerxo_optimize_listing` wrapping `/v1/analyze` and `/v1/optimize`.
  - Introduced `callSeerxoV1` reusing existing HMAC signing and error handling.
  - Schemas accept partial listing fields and explain why a bare Etsy URL isn’t enough.
  - Markdown output: SEO score + sub-scores, ranked weak points with fixes, missing keywords, tag-slot usage; optimize shows before→after score, resolved IDs, and rewritten fields.
  - Added `tests/listing-tools.test.js`.

- **Bug Fixes**
  - `npm test` now uses Node’s default test discovery (`node --test`) to avoid Node 22 glob issues.

<sup>Written for commit fba30fd8bf2e48bb7d4d1116335fcea29a928831. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

