### PR TITLE
feat(mcp): seerxo_suggest_keywords tool

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -820,6 +820,7 @@ async function callSeerxoV1(pathname, payload) {
 // Map MCP tool arguments onto the /v1 audit request body.
 export function buildListingPayload(toolArgs = {}) {
   const payload = {};
+  if (toolArgs.seed) payload.seed = toolArgs.seed;
   if (toolArgs.product_name) payload.productName = toolArgs.product_name;
   if (toolArgs.title) payload.title = toolArgs.title;
   if (toolArgs.description) payload.description = toolArgs.description;
@@ -848,6 +849,19 @@ const LISTING_INPUT_PROPERTIES = {
 };
 
 export const LISTING_TOOLS = [
+  {
+    name: 'seerxo_suggest_keywords',
+    description:
+      'Get ranked Etsy keyword suggestions for a product or seed phrase, sampled from Etsy\'s own search autocomplete (relative demand rank, never fabricated volumes). Each keyword comes with a placement recommendation (title / tags / description) and whether the listing already uses it. Pass the listing fields too when you have them for better placement advice.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        seed: { type: 'string', description: 'Seed phrase to expand (e.g. "ceramic mug"). Falls back to product_name or title.' },
+        ...LISTING_INPUT_PROPERTIES,
+      },
+      required: [],
+    },
+  },
   {
     name: 'seerxo_analyze_listing',
     description:
@@ -898,6 +912,17 @@ export function formatOptimizeResult(data) {
     `## Title\n${optimized.title}\n\n` +
     `## Description\n${optimized.description}\n\n` +
     `## Tags (${(optimized.tags || []).length})\n${(optimized.tags || []).join(', ')}`
+  );
+}
+
+export function formatKeywordsResult(data) {
+  const rows = (data.keywords || [])
+    .map((k) => `${k.demandRank}. **${k.keyword}** → ${k.placement}${k.inListing ? ' (already in listing)' : ''}`)
+    .join('\n');
+  return (
+    `# Keyword Suggestions for "${data.seed}"\n\n` +
+    `Source: Etsy search autocomplete (relative demand order) · confidence: ${data.confidence}\n\n` +
+    `${rows || 'No suggestions found for this seed.'}`
   );
 }
 
@@ -1318,6 +1343,13 @@ export function startMcpServer() {
             };
 
             console.log(JSON.stringify(response));
+          } else if (name === 'seerxo_suggest_keywords') {
+            const data = await callSeerxoV1('/v1/keywords', buildListingPayload(toolArgs));
+            console.log(JSON.stringify({
+              jsonrpc: '2.0',
+              id: request.id,
+              result: { content: [{ type: 'text', text: formatKeywordsResult(data) }] },
+            }));
           } else if (name === 'seerxo_analyze_listing' || name === 'seerxo_optimize_listing') {
             const isAnalyze = name === 'seerxo_analyze_listing';
             const data = await callSeerxoV1(

--- a/tests/listing-tools.test.js
+++ b/tests/listing-tools.test.js
@@ -5,12 +5,13 @@ import {
   buildListingPayload,
   formatAnalyzeResult,
   formatOptimizeResult,
+  formatKeywordsResult,
 } from '../mcp-server.js';
 
 describe('listing tool definitions', () => {
-  it('exposes both tools with agent-usable schemas', () => {
+  it('exposes the listing tools with agent-usable schemas', () => {
     const names = LISTING_TOOLS.map((t) => t.name);
-    assert.deepStrictEqual(names, ['seerxo_analyze_listing', 'seerxo_optimize_listing']);
+    assert.deepStrictEqual(names, ['seerxo_suggest_keywords', 'seerxo_analyze_listing', 'seerxo_optimize_listing']);
     for (const tool of LISTING_TOOLS) {
       assert.ok(tool.description.length > 50, 'description should tell the agent when/how to call');
       assert.strictEqual(tool.inputSchema.type, 'object');
@@ -81,6 +82,25 @@ describe('formatters', () => {
     assert.ok(text.includes('still open: tags_multiword'));
     assert.ok(text.includes('New Title'));
     assert.ok(text.includes('a b, c d'));
+  });
+
+  it('renders keyword suggestions with rank, placement, and confidence', () => {
+    const text = formatKeywordsResult({
+      seed: 'ceramic mug',
+      confidence: 'medium',
+      keywords: [
+        { keyword: 'ceramic mug set', demandRank: 1, placement: 'title', inListing: false },
+        { keyword: 'ceramic mug handmade', demandRank: 2, placement: 'description', inListing: true },
+      ],
+    });
+    assert.ok(text.includes('"ceramic mug"'));
+    assert.ok(text.includes('confidence: medium'));
+    assert.ok(text.includes('1. **ceramic mug set** → title'));
+    assert.ok(text.includes('(already in listing)'));
+  });
+
+  it('maps seed onto the keywords payload', () => {
+    assert.deepStrictEqual(buildListingPayload({ seed: 'ceramic mug' }), { seed: 'ceramic mug' });
   });
 
   it('flags the fallback case honestly', () => {


### PR DESCRIPTION
## Summary
- New MCP tool **`seerxo_suggest_keywords`** wrapping the backend's `POST /v1/keywords` 1:1: ranked suggestions from Etsy's own autocomplete (relative `demandRank`, never fabricated volumes), per-keyword placement recommendation (title/tags/description), `inListing` flag, honest confidence.
- Reuses `callSeerxoV1` + `buildListingPayload` (adds `seed` mapping); output rendered as compact markdown for agents.

## Test plan
- `npm test` → 8/8 pass; lint clean.
- End-to-end stdio smoke against a local backend: `tools/list` shows 4 tools, `seerxo_suggest_keywords` returns formatted ranked suggestions with confidence.

Depends on semihbugrasezer/seerxo-backend#49 being deployed for production use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new MCP tool `seerxo_suggest_keywords` that returns ranked Etsy autocomplete keywords with placement advice and confidence. Also adds `seed` support in listing payloads and a formatter for compact markdown output.

- **New Features**
  - New tool `seerxo_suggest_keywords` calling `POST /v1/keywords`.
  - Input supports optional `seed`; uses listing fields for better placement advice.
  - Maps `seed` in `buildListingPayload`; renders results with `formatKeywordsResult` (demand rank, placement, in-listing flag, confidence).

- **Dependencies**
  - Requires seerxo-backend PR `#49` deployed for production.

<sup>Written for commit c3a6ed09623e52d2260b83e199b7e68543d832ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

