### PR TITLE
feat(cli): analyze, optimize, and keywords commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 Front-loaded SEO title (+ A/B variants) · hook-first description · all **13 tags** ·
 Etsy attributes — generated in seconds, ready to paste.
+Then keep improving: **score**, **fix**, and **keyword-mine** existing listings from the same CLI, MCP server, and Claude Code skill.
 
 **[Try it free →](https://www.seerxo.com)**&ensp;·&ensp;[Quick start](#-quick-start)&ensp;·&ensp;[Sample output](#-see-it-work)
 
@@ -68,9 +69,19 @@ seerxo login     # Google sign-in in your browser; API key is saved for you
 seerxo generate --product "boho macrame wall hanging" --category "Home & Living"
 ```
 
+Already have a listing? Score it, fix it, and mine keywords from the same CLI:
+
+```bash
+seerxo analyze  --title "Minimalist Mug" --tags "mug,gift" --description "..."   # SEO score + weak points
+seerxo optimize --title "Minimalist Mug" --tags "mug,gift" --description "..."   # guided rewrite, before/after score
+seerxo keywords --seed "ceramic mug"                                             # ranked Etsy autosuggest keywords
+```
+
+(`seerxo audit` works as an alias for `analyze`.)
+
 Prefer interactive? Just run `seerxo` and type your product
 (add a category with `|`, e.g. `Boho bedroom wall art set | Wall Art`).
-Add `--json` to any generate for machine-readable output.
+Add `--json` to any command for machine-readable output.
 
 <details id="claude-desktop-mcp">
 <summary><b>🤖 Claude Desktop (MCP) setup</b></summary>

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -111,6 +111,7 @@ function normalizeCommandName(command) {
   const value = typeof command === 'string' ? command.trim().toLowerCase() : '';
   if (value === 'signin' || value === 'sign-in') return 'login';
   if (value === 'signout' || value === 'sign-out') return 'logout';
+  if (value === 'audit') return 'analyze';
   return value;
 }
 
@@ -368,6 +369,9 @@ const printUsage = () => {
       `  seerxo configure [--email you@example.com --api-key keyId.secret --host https://api.seerxo.com]\n` +
       `  seerxo quota        # show remaining credits\n` +
       `  seerxo generate --product \"...\" [--category \"...\"] [--json]\n` +
+      `  seerxo analyze  --title \"...\" [--tags \"a,b,c\" --description \"...\" --product \"...\"] [--json]\n` +
+      `  seerxo optimize --title \"...\" [--tags \"a,b,c\" --description \"...\" --product \"...\"] [--json]\n` +
+      `  seerxo keywords --seed \"ceramic mug\" [--title \"...\" --tags \"a,b,c\"] [--json]\n` +
       `  seerxo skill add|remove|path [--project]   # Claude Code skill\n` +
       `  seerxo update|upgrade   # update CLI to latest\n` +
       `  seerxo --help           # show this message\n` +
@@ -1210,6 +1214,53 @@ export async function handleCli(subArgs) {
       }
     } catch (error) {
       console.error(error.message || 'Content generation failed');
+      process.exitCode = 1;
+      return;
+    }
+    return;
+  }
+
+  if (sub === 'analyze' || sub === 'optimize' || sub === 'keywords') {
+    const jsonOutput = subArgs.includes('--json');
+    const flag = (name) => {
+      const index = subArgs.indexOf(`--${name}`);
+      return index !== -1 && subArgs[index + 1] ? subArgs[index + 1] : undefined;
+    };
+    const rawTags = flag('tags');
+    const payload = buildListingPayload({
+      seed: flag('seed'),
+      product_name: flag('product'),
+      title: flag('title'),
+      description: flag('description'),
+      tags: rawTags ? rawTags.split(',').map((tag) => tag.trim()).filter(Boolean) : undefined,
+      url: flag('url'),
+    });
+    if (Object.keys(payload).length === 0) {
+      console.error(
+        sub === 'keywords'
+          ? 'Missing input: pass --seed "ceramic mug" (or --product / --title).'
+          : `Missing input: pass at least one of --title / --tags / --description (tags are comma-separated).`
+      );
+      process.exitCode = 1;
+      return;
+    }
+    try {
+      const data = await callSeerxoV1(sub === 'keywords' ? '/v1/keywords' : `/v1/${sub}`, payload);
+      if (jsonOutput) {
+        console.log(JSON.stringify(data, null, 2));
+      } else {
+        const text =
+          sub === 'analyze'
+            ? formatAnalyzeResult(data)
+            : sub === 'optimize'
+              ? formatOptimizeResult(data)
+              : formatKeywordsResult(data);
+        console.log(
+          boxen(text, { padding: 1, borderColor: 'cyan', borderStyle: 'round', title: 'seerxo' })
+        );
+      }
+    } catch (error) {
+      console.error(error.message || `${sub} failed`);
       process.exitCode = 1;
       return;
     }

--- a/tests/listing-tools.test.js
+++ b/tests/listing-tools.test.js
@@ -6,6 +6,7 @@ import {
   formatAnalyzeResult,
   formatOptimizeResult,
   formatKeywordsResult,
+  handleCli,
 } from '../mcp-server.js';
 
 describe('listing tool definitions', () => {
@@ -113,5 +114,40 @@ describe('formatters', () => {
       fallback: true,
     });
     assert.ok(text.includes('original fields were kept'));
+  });
+});
+
+describe('cli listing commands', () => {
+  const captureError = async (args) => {
+    const original = console.error;
+    const lines = [];
+    console.error = (...parts) => lines.push(parts.join(' '));
+    const exitBefore = process.exitCode;
+    try {
+      await handleCli(args);
+    } finally {
+      console.error = original;
+    }
+    const failed = process.exitCode === 1;
+    process.exitCode = exitBefore;
+    return { lines, failed };
+  };
+
+  it('rejects analyze without any listing input', async () => {
+    const { lines, failed } = await captureError(['analyze']);
+    assert.ok(failed);
+    assert.ok(lines.join(' ').includes('--title'));
+  });
+
+  it('treats audit as an alias for analyze', async () => {
+    const { lines, failed } = await captureError(['audit']);
+    assert.ok(failed);
+    assert.ok(lines.join(' ').includes('--title'));
+  });
+
+  it('rejects keywords without a seed', async () => {
+    const { lines, failed } = await captureError(['keywords']);
+    assert.ok(failed);
+    assert.ok(lines.join(' ').includes('--seed'));
   });
 });


### PR DESCRIPTION
## Summary
- `seerxo analyze` (alias `audit`), `seerxo optimize`, `seerxo keywords` CLI commands — thin wrappers over the same `/v1/*` endpoints the MCP tools use (`callSeerxoV1` + existing formatters), with `--json` support
- `--help` usage text and README updated: the outer story now covers score → fix → keyword-mine, not just generate

## Test plan
- `npm test` — 11/11 pass (3 new CLI input-validation tests incl. the audit alias)
- `node --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CLI commands `seerxo analyze` (alias `audit`), `seerxo optimize`, and `seerxo keywords` to score, fix, and keyword-mine existing listings. They call the same `/v1/*` endpoints used by the MCP tools and support `--json`; help text and README are updated.

- **New Features**
  - Normalize `audit` to `analyze` and show new commands in `--help`; README adds examples and the score → fix → keyword-mine flow.
  - Validate inputs with clear errors for missing `--title/--tags/--description` or `--seed`.
  - Add tests for CLI input validation and alias handling.

<sup>Written for commit f320a7f83eedc27937c770cf4ec7cd6289518271. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

