### PR TITLE
docs(readme): fix dead extension link, align pricing with AI actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ each tag ≤20 chars, lowercase, no duplicates.
 | 🤖 **Claude Desktop (MCP)** | "Generate a listing" mid-conversation | [Setup ↓](#claude-desktop-mcp) |
 | 🧑‍💻 **Claude Code skill** | Listings without leaving your editor | `seerxo skill add` |
 | 🌐 **[Web app](https://www.seerxo.com)** | Zero install + free [SEO Score audit](https://www.seerxo.com/audit) | Open and type |
-| 🧩 **[Chrome extension](https://github.com/semihbugrasezer/seerxo-chrome-extension)** | Optimize on the Etsy page itself | Early preview |
 
 One account, one credit pool — every channel shares it.
 
@@ -157,7 +156,8 @@ Check state anytime with `seerxo status`; sign out with `seerxo logout`.
 
 | | Free | Premium |
 |---|---|---|
-| Generations | **5** / month | up to **300** / month — [Upgrade →](https://www.seerxo.com/pricing) |
+| Listing audit (`analyze`) | **Unlimited** | Unlimited |
+| AI actions (generate, optimize, keywords) | **5** / month | up to **300** / month — [Upgrade →](https://www.seerxo.com/pricing) |
 
 Both plans include every channel — CLI, Claude Desktop, Claude Code skill, and the web app.
 


### PR DESCRIPTION
## Summary
- **Chrome Extension link was dead** — it points to `seerxo-chrome-extension`, a private repo, so every reader hit a 404. Same bug already fixed on the seerxo.com footer this session. Removed the row until the repo goes public.
- **Pricing table said "Generations"** with one undifferentiated row. The actual product (per the live pricing page's own FAQ: *"One generation, optimization, or keyword search uses one AI action. Public listing audits are free and do not use your monthly allowance."*) separates:
  - `analyze` (listing audit) — unlimited on every plan
  - `generate` / `optimize` / `keywords` — the metered "AI actions" pool (5 free / 300 premium)

## Note (not fixed here, flagging for awareness)
While reading `seerxo-backend`'s `/v1/*` routes to verify this, I noticed `/v1/analyze`, `/v1/optimize`, and `/v1/keywords` only call `recordApiUsage()` (stats) — none of them run a quota-check middleware like `/api/generate`'s `userQuotaCheck`. So today, a Free-plan CLI/API-key user can call optimize/keywords unlimited times with no quota block, even though the product copy says they're metered. That's a backend business-logic question (intentional API-key perk vs. gap), not a CLI-repo doc fix, so I left it alone — flagging in case it's not intentional.

## Test plan
- [x] `npm run build` (package validation) — passed
- [x] `node --check mcp-server.js && node --check utils.js` — clean
- [x] `npm test` — 11/11 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Chrome Extension row in the README because it linked to a private repo (404).
Updated the pricing table to show unlimited listing audits (`analyze`) and a metered pool for generate/optimize/keywords (5 free, up to 300 on Premium), matching the live pricing page.

<sup>Written for commit 2420841528e747e2e06c6ec6eddd46f84e7ec45a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

