### PR TITLE
feat(cli+skill): make analyze/optimize/keywords fully reachable

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -370,7 +370,7 @@ const printUsage = () => {
       `  seerxo quota        # show remaining credits\n` +
       `  seerxo generate --product \"...\" [--category \"...\"] [--json]\n` +
       `  seerxo analyze  --title \"...\" [--tags \"a,b,c\" --description \"...\" --product \"...\"] [--json]\n` +
-      `  seerxo optimize --title \"...\" [--tags \"a,b,c\" --description \"...\" --product \"...\"] [--json]\n` +
+      `  seerxo optimize --title \"...\" [--tags \"a,b,c\" --description \"...\" --product \"...\"] [--mode full|title_only|description_only|tags_only] [--json]\n` +
       `  seerxo keywords --seed \"ceramic mug\" [--title \"...\" --tags \"a,b,c\"] [--json]\n` +
       `  seerxo skill add|remove|path [--project]   # Claude Code skill\n` +
       `  seerxo update|upgrade   # update CLI to latest\n` +
@@ -412,6 +412,9 @@ const printCliBanner = () => {
     `${chalk.cyan('configure')}  ${chalk.gray('Set email & API key')}`,
     `${chalk.cyan('generate')}   ${chalk.gray('Guided prompt (product/category)')}`,
     `${chalk.cyan('quit')}       ${chalk.gray('Exit interactive mode')}`,
+    '',
+    chalk.gray('  analyze / optimize / keywords take flags — run them from your shell,'),
+    chalk.gray('  e.g. seerxo analyze --title "..." --tags "a,b" (see: seerxo help)'),
   ].join('\n');
 
   console.log(
@@ -876,7 +879,18 @@ export const LISTING_TOOLS = [
     name: 'seerxo_optimize_listing',
     description:
       'Rewrite an Etsy listing to fix its audit findings: improved title, description, and tag set, each mapped to the finding it resolves, with a before/after SEO score. Etsy limits (140-char title, 13 tags, 20 chars per tag) are enforced server-side and the result never scores below the original. Provide the current listing fields.',
-    inputSchema: { type: 'object', properties: LISTING_INPUT_PROPERTIES, required: [] },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ...LISTING_INPUT_PROPERTIES,
+        mode: {
+          type: 'string',
+          enum: ['full', 'title_only', 'description_only', 'tags_only'],
+          description: 'Which field(s) to rewrite. Defaults to "full" (title + description + tags). Use a single-field mode to rewrite just that field and leave the rest untouched.',
+        },
+      },
+      required: [],
+    },
   },
 ];
 
@@ -908,11 +922,14 @@ export function formatOptimizeResult(data) {
   const fallbackNote = data.fallback
     ? '\n\n> Note: the rewrite did not beat the original listing, so the original fields were kept.'
     : '';
+  const modeNote = data.mode && data.mode !== 'full'
+    ? ` · only the ${data.mode.replace('_only', '')} was rewritten`
+    : '';
 
   return (
     `# Optimized Listing\n\n` +
     `**SEO Score: ${before.seoScore} → ${after.seoScore}** · resolved ${data.resolved?.length ?? 0} finding(s)` +
-    `${data.unresolved?.length ? `, still open: ${data.unresolved.join(', ')}` : ''}${fallbackNote}\n\n` +
+    `${data.unresolved?.length ? `, still open: ${data.unresolved.join(', ')}` : ''}${modeNote}${fallbackNote}\n\n` +
     `## Title\n${optimized.title}\n\n` +
     `## Description\n${optimized.description}\n\n` +
     `## Tags (${(optimized.tags || []).length})\n${(optimized.tags || []).join(', ')}`
@@ -1028,6 +1045,18 @@ export async function startInteractiveShell() {
         return promptLoop();
       }
 
+      if (cmd === 'analyze' || cmd === 'audit' || cmd === 'optimize' || cmd === 'keywords') {
+        const command = cmd === 'audit' ? 'analyze' : cmd;
+        console.log(
+          `\n${chalk.cyan(command)} takes flags, so run it from your shell instead of this prompt, e.g.\n` +
+            (command === 'keywords'
+              ? chalk.gray(`  seerxo keywords --seed "ceramic mug"`)
+              : chalk.gray(`  seerxo ${command} --title "Minimalist Mug" --tags "mug,gift" --description "..."`)) +
+            '\n'
+        );
+        continue;
+      }
+
       if (cmd === 'help') {
         console.log(
           '\n' +
@@ -1122,7 +1151,7 @@ export async function startInteractiveShell() {
 export async function handleCli(subArgs) {
   const sub = normalizeCommandName(subArgs[0]);
 
-  if (!sub || sub === '--help' || sub === '-h') {
+  if (!sub || sub === '--help' || sub === '-h' || sub === 'help') {
     printCliBanner();
     printUsage();
     return;
@@ -1235,6 +1264,7 @@ export async function handleCli(subArgs) {
       tags: rawTags ? rawTags.split(',').map((tag) => tag.trim()).filter(Boolean) : undefined,
       url: flag('url'),
     });
+    if (sub === 'optimize' && flag('mode')) payload.mode = flag('mode');
     if (Object.keys(payload).length === 0) {
       console.error(
         sub === 'keywords'
@@ -1403,10 +1433,9 @@ export function startMcpServer() {
             }));
           } else if (name === 'seerxo_analyze_listing' || name === 'seerxo_optimize_listing') {
             const isAnalyze = name === 'seerxo_analyze_listing';
-            const data = await callSeerxoV1(
-              isAnalyze ? '/v1/analyze' : '/v1/optimize',
-              buildListingPayload(toolArgs)
-            );
+            const payload = buildListingPayload(toolArgs);
+            if (!isAnalyze && toolArgs.mode) payload.mode = toolArgs.mode;
+            const data = await callSeerxoV1(isAnalyze ? '/v1/analyze' : '/v1/optimize', payload);
 
             const response = {
               jsonrpc: '2.0',

--- a/skills/seerxo-etsy-seo/SKILL.md
+++ b/skills/seerxo-etsy-seo/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: seerxo-etsy-seo
-description: Generate or optimize a complete, copy-paste-ready Etsy listing — front-loaded title (+ A/B variants), hook-first description, 13 search-optimized tags, and the Etsy listing attributes to set — by calling the Seerxo CLI. Accepts a product phrase or a pasted Etsy listing URL. Use whenever the user wants Etsy SEO, an Etsy listing, product tags, a title/description, or wants to improve/rank an existing Etsy listing.
+description: Generate, score, fix, or research keywords for an Etsy listing — front-loaded title (+ A/B variants), hook-first description, 13 search-optimized tags, an explainable 0-100 SEO score with ranked weak points, guided rewrites, and ranked keyword ideas — by calling the Seerxo CLI. Accepts a product phrase or a pasted Etsy listing URL. Use whenever the user wants an Etsy listing, Etsy SEO, an SEO score / listing audit, to fix or rank-up an existing listing, or Etsy keyword ideas.
 ---
 
 # Seerxo · Etsy SEO
 
 One CLI call turns a short product description into a complete, copy-paste-ready Etsy
-listing. Always call the CLI — never hand-write the listing — so output stays on-quota
-and consistent with the Seerxo web app, dashboard, and MCP server (they share credits).
+listing — or scores, fixes, or keyword-mines a listing that already exists. Always call
+the CLI — never hand-write the listing or invent a score — so output stays on-quota and
+consistent with the Seerxo web app, dashboard, and MCP server (they share credits).
 
 ## When to use
 
 Trigger when the user wants any of: an Etsy listing, Etsy SEO, a product title, a
-product description, Etsy tags, or to optimize / rank-up an existing Etsy listing.
+product description, Etsy tags, an SEO score / listing audit, to fix or rank-up an
+existing Etsy listing, or Etsy keyword ideas.
 
 ## Generate
 
@@ -48,7 +50,7 @@ Always pass `--json` and parse the result. Shape:
 }
 ```
 
-## Present it — copy-paste ready
+### Present it — copy-paste ready
 
 Format the result so the seller can paste each block straight into Etsy. Use these
 exact labels and keep it scannable:
@@ -70,15 +72,115 @@ exact labels and keep it scannable:
 Ship exactly what the CLI returned — do not add, drop, or rewrite tags yourself. The CLI
 already enforces 13 tags, ≤20 chars, lowercase, and no duplicates; trust its output.
 
+## Score / audit an existing listing
+
+The user has a listing already and wants to know how it's doing — "score my listing",
+"audit this", "why isn't this ranking". **This is free and unlimited on every plan** —
+it never uses a generation credit, so call it freely, even just to check before/after.
+
+Gather whatever fields the user has (title, tags, description — at least one; a pasted
+listing URL adds the product name from its slug but doesn't replace the fields above,
+since Etsy blocks server-side fetches) and run:
+
+```bash
+seerxo analyze --title "Speckled Ceramic Coffee Mug" --tags "handmade mug,ceramic cup" --description "..." --json
+```
+
+(`seerxo audit` is an alias for the same command.)
+
+Shape:
+
+```json
+{
+  "seoScore": 62,
+  "subScores": { "title": 80, "tags": 40, "description": 100, "completeness": 66 },
+  "weakPoints": [{ "field": "tags", "severity": "high", "reason": "…", "fix": "…" }],
+  "missingKeywords": ["12oz"],
+  "tagUtilization": { "used": 7, "max": 13, "duplicates": [], "tooBroad": [], "overLong": [] }
+}
+```
+
+Present: the overall `seoScore`/100, the four `subScores`, each `weakPoints` entry as
+`[severity] reason → fix`, `missingKeywords` the listing should work in, and
+`tagUtilization` as "X/13 tag slots used" with any duplicates/too-broad/over-long notes.
+If the score is already high and `weakPoints` is empty, say so plainly — don't invent
+issues to fill space.
+
+## Fix it (optimize)
+
+Once the user has seen the audit (or asks directly to "fix"/"improve"/"rewrite" a
+listing), rewrite it. **This uses one credit** (same shared pool as `generate`) — unlike
+`analyze`, so don't call it speculatively; only when the user wants the rewrite.
+
+```bash
+seerxo optimize --title "Speckled Ceramic Coffee Mug" --tags "handmade mug,ceramic cup" --description "..." --json
+```
+
+The rewrite touches title + description + tags by default. If the user only wants ONE
+field fixed ("just fix the title"), pass `--mode`:
+
+```bash
+seerxo optimize --title "..." --tags "a,b,c" --description "..." --mode title_only --json
+```
+
+`--mode` accepts `full` (default), `title_only`, `description_only`, or `tags_only` —
+untouched fields are returned exactly as given.
+
+Shape:
+
+```json
+{
+  "before": { "seoScore": 62 },
+  "after": { "seoScore": 88 },
+  "optimized": { "title": "…", "description": "…", "tags": ["…"] },
+  "resolved": ["tags_count"],
+  "unresolved": [],
+  "fallback": false,
+  "mode": "full"
+}
+```
+
+Present the score change (`before.seoScore → after.seoScore`), how many findings were
+`resolved` (and any still `unresolved`), then the rewritten fields — copy-paste ready,
+same formatting rules as Generate. If `fallback` is `true`, say plainly that the rewrite
+didn't beat the original, so the original was kept (the score never regresses).
+
+## Find more keywords
+
+"What else should I tag this with" / "keyword ideas for X" → run:
+
+```bash
+seerxo keywords --seed "ceramic mug" --json
+```
+
+Pass the listing's `--title`/`--tags`/`--description` too when available — it marks
+which suggestions are already in the listing vs. missing. Shape:
+
+```json
+{
+  "seed": "ceramic mug",
+  "confidence": "medium",
+  "keywords": [{ "keyword": "ceramic mug set", "demandRank": 1, "placement": "title", "inListing": false }]
+}
+```
+
+Present as a ranked list (`demandRank` order): `keyword → placement recommendation`,
+flagging which are already in the listing. These are relative-demand ranks sampled from
+Etsy's own search autocomplete — never state or imply an absolute search-volume number.
+
 ## Errors → the exact fix
 
 - `command not found: seerxo` → tell the user to run `npm install -g seerxo`.
 - "Email is not set" / "Invalid API key" / "Run seerxo login" → run `seerxo login`
   (opens a browser for Google sign-in), then retry. To inspect state: `seerxo status`.
-- "Monthly quota exceeded" → the account is out of credits; upgrade at
-  https://www.seerxo.com (Free = 5/month, Premium = up to 300/month).
+- "Monthly quota exceeded" → the account is out of AI-action credits (this only happens
+  on `generate`/`optimize`/`keywords` — `analyze` is unaffected); upgrade at
+  https://www.seerxo.com/pricing (Free = 5/month, Premium = up to 300/month).
+- Invalid `--mode` value → the CLI returns the accepted list; re-run with one of
+  `full` / `title_only` / `description_only` / `tags_only`.
 
-## Multiple products
+## Multiple listings
 
-If the user lists several products, run one `seerxo generate` per product and present
-each listing under its own heading. One generation = one credit.
+If the user lists several products or listings, run one CLI call per item and present
+each result under its own heading. One `generate`, `optimize`, or `keywords` call = one
+credit; `analyze` calls are free, however many you run.

--- a/tests/listing-tools.test.js
+++ b/tests/listing-tools.test.js
@@ -21,6 +21,16 @@ describe('listing tool definitions', () => {
       }
     }
   });
+
+  it('exposes a mode enum on seerxo_optimize_listing', () => {
+    const optimizeTool = LISTING_TOOLS.find((t) => t.name === 'seerxo_optimize_listing');
+    assert.deepStrictEqual(optimizeTool.inputSchema.properties.mode.enum, [
+      'full',
+      'title_only',
+      'description_only',
+      'tags_only',
+    ]);
+  });
 });
 
 describe('buildListingPayload', () => {
@@ -104,6 +114,19 @@ describe('formatters', () => {
     assert.deepStrictEqual(buildListingPayload({ seed: 'ceramic mug' }), { seed: 'ceramic mug' });
   });
 
+  it('notes when only a single field was rewritten', () => {
+    const text = formatOptimizeResult({
+      before: { seoScore: 62 },
+      after: { seoScore: 88 },
+      optimized: { title: 'New Title', description: 'Same description.', tags: ['a', 'b'] },
+      resolved: ['title_length'],
+      unresolved: [],
+      fallback: false,
+      mode: 'title_only',
+    });
+    assert.ok(text.includes('only the title was rewritten'));
+  });
+
   it('flags the fallback case honestly', () => {
     const text = formatOptimizeResult({
       before: { seoScore: 90 },
@@ -149,5 +172,22 @@ describe('cli listing commands', () => {
     const { lines, failed } = await captureError(['keywords']);
     assert.ok(failed);
     assert.ok(lines.join(' ').includes('--seed'));
+  });
+
+  it('treats bare "help" the same as --help', async () => {
+    const original = console.log;
+    const lines = [];
+    console.log = (...parts) => lines.push(parts.join(' '));
+    const exitBefore = process.exitCode;
+    try {
+      await handleCli(['help']);
+    } finally {
+      console.log = original;
+    }
+    const failed = process.exitCode === 1;
+    process.exitCode = exitBefore;
+
+    assert.ok(!failed);
+    assert.ok(lines.join('\n').includes('seerxo optimize'));
   });
 });


### PR DESCRIPTION
## Summary
Auditing the CLI end to end (per "tüm fonksiyonlar çalışır halde olmalı") surfaced several places where `analyze`/`optimize`/`keywords` existed but weren't fully wired up:

- **Claude Code skill** only knew about `generate`. Added dedicated sections for scoring (free/unlimited), fixing (`optimize`, 1 credit), and keyword research (`keywords`, 1 credit) — with the real JSON contracts and presentation rules, matching how the web app already presents these.
- **`--mode` was CLI/MCP-only missing**: the backend and web app support single-field rewrites (`title_only`/`description_only`/`tags_only`), but the CLI flag, the `seerxo_optimize_listing` MCP tool schema, and its handler never passed it through. Fixed all three.
- **Interactive mode was silently wrong**: typing `analyze`, `optimize`, or `keywords` at the bare `seerxo` prompt fell through to "generate a listing for the product 'analyze'" instead of doing anything sensible. Now it redirects to the correct shell command.
- **`seerxo help` (no dashes)** hit the `[seerxo] Unknown command` fallback (with exit code 1) instead of just showing usage like `--help` does.
- `printUsage()` didn't mention `--mode`.

## Test plan
- [x] `npm test` — 14/14 (4 new: optimize tool's mode enum, mode note in `formatOptimizeResult`, `seerxo help` parity — plus regression coverage already in place)
- [x] `npm run build` (package validation) — passed
- [x] `node --check mcp-server.js` — clean
- [x] Manually ran `seerxo --help` / `seerxo help` and confirmed identical output including the new `--mode` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `analyze`, `optimize`, and `keywords` fully usable across the CLI, MCP server, and `seerxo-etsy-seo` skill, with a new `--mode` flag for single‑field rewrites and clearer help/UX.

- **New Features**
  - `seerxo optimize` now supports `--mode full|title_only|description_only|tags_only`; usage text updated.
  - MCP: `seerxo_optimize_listing` schema exposes `mode` and passes it through to `/v1/optimize`.
  - Output: `formatOptimizeResult` notes when only one field was rewritten.
  - Skill docs: added sections for scoring/auditing (free), fixing via optimize (1 credit, `--mode` supported), and keyword research (1 credit), with JSON shapes and presentation rules.

- **Bug Fixes**
  - Interactive CLI no longer treats `analyze`/`optimize`/`keywords` as a product; it shows how to run the proper shell command.
  - `seerxo help` now aliases to `--help` and prints usage with exit code 0.

<sup>Written for commit 091181617d93dd70a432ba500f96e9f162b0dca6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

