### PR TITLE
fix(cli): validate listing input before applying --mode

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -1264,7 +1264,6 @@ export async function handleCli(subArgs) {
       tags: rawTags ? rawTags.split(',').map((tag) => tag.trim()).filter(Boolean) : undefined,
       url: flag('url'),
     });
-    if (sub === 'optimize' && flag('mode')) payload.mode = flag('mode');
     if (Object.keys(payload).length === 0) {
       console.error(
         sub === 'keywords'
@@ -1274,6 +1273,7 @@ export async function handleCli(subArgs) {
       process.exitCode = 1;
       return;
     }
+    if (sub === 'optimize' && flag('mode')) payload.mode = flag('mode');
     try {
       const data = await callSeerxoV1(sub === 'keywords' ? '/v1/keywords' : `/v1/${sub}`, payload);
       if (jsonOutput) {

--- a/tests/listing-tools.test.js
+++ b/tests/listing-tools.test.js
@@ -162,6 +162,12 @@ describe('cli listing commands', () => {
     assert.ok(lines.join(' ').includes('--title'));
   });
 
+  it('rejects optimize --mode with no listing fields instead of calling the API', async () => {
+    const { lines, failed } = await captureError(['optimize', '--mode', 'title_only']);
+    assert.ok(failed);
+    assert.ok(lines.join(' ').includes('--title'));
+  });
+
   it('treats audit as an alias for analyze', async () => {
     const { lines, failed } = await captureError(['audit']);
     assert.ok(failed);


### PR DESCRIPTION
## Summary
Fixes a bug flagged by automated review (cubic) on #76 after merge: `payload.mode = flag('mode')` ran **before** the empty-payload guard in the `analyze`/`optimize`/`keywords` handler. So `seerxo optimize --mode title_only` with no `--title`/`--tags`/`--description` had a non-empty payload (`{ mode: 'title_only' }`), skipped the intended "Missing input: pass at least one of --title / --tags / --description" CLI error, and sent an incomplete payload straight to the API instead of failing fast with a clear message.

Moved the `mode` assignment to after the guard.

## Test plan
- [x] New test: `optimize --mode title_only` with no listing fields now fails with the `--title` guidance message (would have hit the network before this fix)
- [x] `npm test` — 15/15
- [x] `npm run build` (package validation) — passed
- [x] `node --check mcp-server.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the `optimize` CLI validates listing input before applying `--mode`. This now shows the "Missing input" error instead of sending a mode-only payload to the API.

- **Bug Fixes**
  - Apply `payload.mode` after the empty-payload guard in `mcp-server.js`.
  - Added test to verify `optimize --mode title_only` without listing fields fails with guidance.

<sup>Written for commit dcae0c1737238934773803f8f98800b835d8c932. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

