### PR TITLE
feat: publish to the official MCP Registry on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,33 @@ jobs:
         run: npm run build --if-present
 
       - name: Release
+        id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+        # semantic-release bumps package.json in the working tree when it
+        # releases; comparing before/after tells us whether one happened.
+        run: |
+          BEFORE=$(node -p "require('./package.json').version")
+          npx semantic-release
+          AFTER=$(node -p "require('./package.json').version")
+          if [ "$BEFORE" != "$AFTER" ]; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "version=$AFTER" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to MCP Registry
+        if: steps.release.outputs.released == 'true'
+        # Authenticates via GitHub Actions OIDC (id-token: write above) — no
+        # extra secrets. Keeps registry.modelcontextprotocol.io in sync with
+        # every npm release; clients like PulseMCP and Smithery index it.
+        run: |
+          curl -sL "https://api.github.com/repos/modelcontextprotocol/registry/releases/latest" \
+            | jq -r '.assets[] | select(.name | test("linux_amd64.tar.gz$")) | .browser_download_url' \
+            | xargs curl -sL -o mcp-publisher.tar.gz
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+          VERSION="${{ steps.release.outputs.version }}"
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.json.tmp
+          mv server.json.tmp server.json
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish

--- a/package.json
+++ b/package.json
@@ -76,5 +76,6 @@
     "@semantic-release/github": {
       "undici": "^7.28.0"
     }
-  }
+  },
+  "mcpName": "io.github.semihbugrasezer/seerxo"
 }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "io.github.semihbugrasezer/seerxo",
+  "description": "Generate SEO-optimized Etsy listings \u2014 title, description, and 13 tags \u2014 from your AI assistant.",
+  "repository": {
+    "url": "https://github.com/semihbugrasezer/seerxo",
+    "source": "github"
+  },
+  "websiteUrl": "https://www.seerxo.com",
+  "version": "1.8.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "seerxo",
+      "version": "1.8.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "SEERXO_API_KEY",
+          "description": "Optional API key from seerxo.com \u2014 omit to use the free tier set up via 'seerxo configure'.",
+          "isRequired": false,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Lists Seerxo on the official MCP Registry (registry.modelcontextprotocol.io) — currently `?search=seerxo` returns 0 servers there, while aggregators (PulseMCP, Smithery, mcp.so) all index it.

**How it works after merge**
1. This `feat:` commit triggers semantic-release → npm `seerxo@1.9.0` ships with `mcpName`, which is how the registry validates we own the npm package.
2. The new workflow step then publishes `server.json` (version-synced) to the registry via GitHub Actions OIDC — `id-token: write` was already granted, no new secrets.
3. Every future release re-publishes automatically, so the registry never goes stale.

Verified locally: 15/15 tests, lint clean, server.json validates against the 2025-09-29 schema shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish `seerxo` to the official MCP Registry on every release. Keeps the registry listing in sync with npm and discoverable by MCP clients.

- **New Features**
  - Added `server.json` MCP manifest (npm/stdio; optional `SEERXO_API_KEY`).
  - Added `mcpName` to `package.json` to verify npm package ownership.
  - Updated release workflow to publish after a successful `semantic-release`: detect version bump, sync manifest versions, authenticate via GitHub OIDC, run `mcp-publisher`.

<sup>Written for commit 7fb3cde708a7b97b6308b033f4b9184226ffe031. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

