### PR TITLE
docs: add system map, agent instructions and map:check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Agent instructions
+
+## Architecture context
+
+Before making changes, read:
+
+1. `../architecture/SYSTEM_MAP.md` — Seerxo ecosystem (when working inside the workspace)
+2. `docs/SYSTEM_MAP.md` — this repository's internals
+3. The active task file under `../tasks/active/` if present
+
+Repository responsibility:
+
+- npm package: CLI, MCP stdio server, Claude Code skill, API client
+- No product business logic — that belongs in seerxo-backend
+- No direct database access; all requests go HMAC-signed to `api.seerxo.com`
+- Endpoints and MCP tools used here must exist in `seerxo-backend/openapi.yaml`; do not invent endpoints or response fields
+
+Classify every requested change:
+
+- **Local**: CLI UX, formatting, refactor → no map update
+- **Contract**: new/changed endpoint or MCP tool → update `docs/SYSTEM_MAP.md` here and report backend follow-up
+- **Ecosystem**: new component/external service → update `seerxo-backend/architecture/ecosystem.json` in the same change
+
+## Architecture map
+
+Update `docs/SYSTEM_MAP.md` when a change:
+
+- adds or removes an API endpoint,
+- adds or removes an MCP tool,
+- introduces a new module or external service,
+- changes authentication or credential flow,
+- moves responsibility between components.
+
+Small bug fixes and internal implementation changes do not require a map update.
+
+After implementation: run `npm test`, `npm run lint`, `npm run map:check`; report contract changes and remaining cross-repo work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,24 +2,19 @@
 
 ## Architecture context
 
-Before making changes, read:
-
-1. `../architecture/SYSTEM_MAP.md` — Seerxo ecosystem (when working inside the workspace)
-2. `docs/SYSTEM_MAP.md` — this repository's internals
-3. The active task file under `../tasks/active/` if present
+Before making changes, read `docs/SYSTEM_MAP.md` — it describes the runtime flow, component ownership and the MCP tool → endpoint mapping.
 
 Repository responsibility:
 
 - npm package: CLI, MCP stdio server, Claude Code skill, API client
-- No product business logic — that belongs in seerxo-backend
-- No direct database access; all requests go HMAC-signed to `api.seerxo.com`
-- Endpoints and MCP tools used here must exist in `seerxo-backend/openapi.yaml`; do not invent endpoints or response fields
+- No product business logic — that lives server-side behind the public API
+- No direct access to any data store; all requests go signed to `api.seerxo.com`
+- Endpoints and MCP tools used here must match the published API spec (https://seerxo.com/openapi.yaml); do not invent endpoints or response fields
 
 Classify every requested change:
 
 - **Local**: CLI UX, formatting, refactor → no map update
-- **Contract**: new/changed endpoint or MCP tool → update `docs/SYSTEM_MAP.md` here and report backend follow-up
-- **Ecosystem**: new component/external service → update `seerxo-backend/architecture/ecosystem.json` in the same change
+- **Contract**: new/changed endpoint or MCP tool → update `docs/SYSTEM_MAP.md` in the same change and note that the server-side API must ship first
 
 ## Architecture map
 
@@ -33,4 +28,4 @@ Update `docs/SYSTEM_MAP.md` when a change:
 
 Small bug fixes and internal implementation changes do not require a map update.
 
-After implementation: run `npm test`, `npm run lint`, `npm run map:check`; report contract changes and remaining cross-repo work.
+After implementation: run `npm test`, `npm run lint`, `npm run map:check`; report contract changes.

--- a/docs/SYSTEM_MAP.md
+++ b/docs/SYSTEM_MAP.md
@@ -44,7 +44,7 @@ flowchart LR
 | `seerxo_optimize_listing` | `optimize` | `POST /v1/optimize` |
 | `seerxo_suggest_keywords` | `keywords` | `POST /v1/keywords` |
 
-Other endpoints: `GET /mcp/quota` (quota check), `POST /auth/mcp/login` + `/auth/mcp/confirm` (CLI login flow). All must exist in `seerxo-backend/openapi.yaml`.
+Other endpoints: `GET /mcp/quota` (quota check), `POST /auth/mcp/login` + `/auth/mcp/confirm` (CLI login flow). All must match the published API spec (https://seerxo.com/openapi.yaml).
 
 ## Architecture rules
 

--- a/docs/SYSTEM_MAP.md
+++ b/docs/SYSTEM_MAP.md
@@ -1,0 +1,55 @@
+# Seerxo System Map
+
+Architecture map for the Seerxo npm package: CLI, MCP stdio server, Claude Code skill, and API client. Update this file only on architectural changes (see AGENTS.md).
+
+## Runtime flow
+
+```mermaid
+flowchart LR
+  USER[User / AI Client]
+  CLI[CLI Entry]
+  MCP[MCP Entry]
+  CORE[mcp-server.js]
+  CONFIG[Local Config]
+  API[api.seerxo.com]
+  SKILL[Claude Code Skill]
+
+  USER --> CLI
+  USER --> MCP
+  CLI --> CORE
+  MCP --> CORE
+  CORE --> CONFIG
+  CORE --> API
+  CORE --> SKILL
+```
+
+## Component ownership
+
+| Component | Responsibility |
+| --- | --- |
+| `bin/seerxo.js` | Select CLI, interactive or MCP mode |
+| `bin/seerxo-mcp.js` | Start Seerxo as an MCP stdio server |
+| `mcp-server.js` | Runtime orchestration: CLI commands, MCP JSON-RPC, auth, API client, result formatting, skill installer |
+| `utils.js` | API host validation and normalization |
+| `skills/seerxo-etsy-seo/` | Claude Code integration |
+| `~/.seerxo-mcp/config.json` | Local credentials (email, API key, host) — secret |
+| `api.seerxo.com` | Authentication, quota and SEO operations (external) |
+
+## MCP tools → backend endpoints
+
+| MCP tool | CLI command | Endpoint |
+| --- | --- | --- |
+| `generate_etsy_seo` | `generate` | `POST /mcp/generate` |
+| `seerxo_analyze_listing` | `analyze` | `POST /v1/analyze` |
+| `seerxo_optimize_listing` | `optimize` | `POST /v1/optimize` |
+| `seerxo_suggest_keywords` | `keywords` | `POST /v1/keywords` |
+
+Other endpoints: `GET /mcp/quota` (quota check), `POST /auth/mcp/login` + `/auth/mcp/confirm` (CLI login flow). All must exist in `seerxo-backend/openapi.yaml`.
+
+## Architecture rules
+
+1. `bin/` files must remain thin entrypoints.
+2. The npm package must not access the database directly — only the public API.
+3. API keys must never be logged.
+4. New API endpoints and MCP tools must be documented here.
+5. Product logic should gradually move out of `mcp-server.js`.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start": "node bin/seerxo.js",
     "test": "NODE_ENV=test node --test",
     "lint": "node --check mcp-server.js && node --check utils.js && node --check scripts/validate-package-files.mjs",
-    "build": "node scripts/validate-package-files.mjs"
+    "build": "node scripts/validate-package-files.mjs",
+    "map:check": "node scripts/check-system-map.mjs"
   },
   "keywords": [
     "mcp",

--- a/scripts/check-system-map.mjs
+++ b/scripts/check-system-map.mjs
@@ -1,0 +1,33 @@
+// Verifies the files referenced by docs/SYSTEM_MAP.md still exist.
+import { access } from 'node:fs/promises';
+
+const requiredFiles = [
+  'docs/SYSTEM_MAP.md',
+  'bin/seerxo.js',
+  'bin/seerxo-mcp.js',
+  'mcp-server.js',
+  'utils.js',
+  'skills/seerxo-etsy-seo/SKILL.md'
+];
+
+const missing = [];
+
+for (const file of requiredFiles) {
+  try {
+    await access(file);
+  } catch {
+    missing.push(file);
+  }
+}
+
+if (missing.length > 0) {
+  console.error('System map references missing files:');
+
+  for (const file of missing) {
+    console.error(`- ${file}`);
+  }
+
+  process.exit(1);
+}
+
+console.log('System map references are valid.');


### PR DESCRIPTION
Adds the light architecture-map setup for agent context:

- `docs/SYSTEM_MAP.md` — runtime flow (mermaid), component ownership, MCP tool → backend endpoint mapping, architecture rules
- `AGENTS.md` — when the map must (and must not) be updated; change classification (local/contract/ecosystem)
- `scripts/check-system-map.mjs` + `npm run map:check` — validates the map's file references

Verified: `map:check`, `lint`, 17/17 tests, `build` all pass. No runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a system architecture map and agent instructions, plus a `map:check` script to validate map references; docs now point to the published API spec and drop private references. No runtime code changes.

- **New Features**
  - `docs/SYSTEM_MAP.md`: runtime flow, component ownership, MCP tool → backend endpoint mapping, architecture rules; references the public spec (https://seerxo.com/openapi.yaml).
  - `AGENTS.md`: when the map must be updated and change types (Local/Contract); contract checks must match the published API spec.
  - `scripts/check-system-map.mjs` + `npm run map:check` in `package.json`: validates referenced files exist.

<sup>Written for commit e0ae0c37943ae8dd727dd8966208ef9da520fd4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

