### PR TITLE
🧪 Add tests for resolveApiKeyState

### DIFF
--- a/tests/resolveApiKeyState.test.js
+++ b/tests/resolveApiKeyState.test.js
@@ -1,0 +1,121 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { resolveApiKeyState } from "../mcp-server.js";
+
+describe("resolveApiKeyState", () => {
+  it("should parse a valid API key correctly", () => {
+    const keyId = "my-valid-key-id";
+    const secret = "my-valid-secret-123456"; // >= 16 chars
+    const result = resolveApiKeyState(`${keyId}.${secret}`);
+
+    assert.strictEqual(result.isValid, true);
+    assert.deepStrictEqual(result.parts, [keyId, secret]);
+    assert.strictEqual(result.secret, secret);
+    assert.strictEqual(result.header, `${keyId}.${secret}`);
+  });
+
+  it("should trim whitespace from a valid API key", () => {
+    const keyId = "my-valid-key-id";
+    const secret = "my-valid-secret-123456";
+    const result = resolveApiKeyState(`  ${keyId}.${secret}  `);
+
+    assert.strictEqual(result.isValid, true);
+    assert.deepStrictEqual(result.parts, [keyId, secret]);
+    assert.strictEqual(result.secret, secret);
+    assert.strictEqual(result.header, `${keyId}.${secret}`);
+  });
+
+  it("should return isValid=false for keys missing a dot", () => {
+    const result = resolveApiKeyState("just-a-key-without-dot");
+
+    assert.strictEqual(result.isValid, false);
+    assert.deepStrictEqual(result.parts, ["just-a-key-without-dot"]);
+    assert.strictEqual(result.secret, null);
+    assert.strictEqual(result.header, null);
+  });
+
+  it("should return isValid=false for keys with too many dots", () => {
+    const result = resolveApiKeyState("keyId.secret.extra");
+
+    assert.strictEqual(result.isValid, false);
+    assert.deepStrictEqual(result.parts, ["keyId", "secret", "extra"]);
+    assert.strictEqual(result.secret, null);
+    assert.strictEqual(result.header, null);
+  });
+
+  it("should return isValid=false when secret is too short (< 16 chars)", () => {
+    const keyId = "keyId";
+    const secret = "short-secret"; // < 16 chars
+    const result = resolveApiKeyState(`${keyId}.${secret}`);
+
+    assert.strictEqual(result.isValid, false);
+    assert.deepStrictEqual(result.parts, [keyId, secret]);
+    assert.strictEqual(result.secret, null);
+    assert.strictEqual(result.header, null);
+  });
+
+  it("should return isValid=false when keyId is missing", () => {
+    const secret = "my-valid-secret-123456";
+    const result = resolveApiKeyState(`.${secret}`);
+
+    assert.strictEqual(result.isValid, false);
+    assert.deepStrictEqual(result.parts, ["", secret]);
+    assert.strictEqual(result.secret, null);
+    assert.strictEqual(result.header, null);
+  });
+
+  it("should return isValid=false when secret is missing", () => {
+    const keyId = "keyId";
+    const result = resolveApiKeyState(`${keyId}.`);
+
+    assert.strictEqual(result.isValid, false);
+    assert.deepStrictEqual(result.parts, [keyId, ""]);
+    assert.strictEqual(result.secret, null);
+    assert.strictEqual(result.header, null);
+  });
+
+  it("should return isValid=false for empty string input", () => {
+    const result = resolveApiKeyState("");
+
+    assert.strictEqual(result.isValid, false);
+    assert.deepStrictEqual(result.parts, []);
+    assert.strictEqual(result.secret, null);
+    assert.strictEqual(result.header, null);
+  });
+
+  it("should return isValid=false for whitespace-only string input", () => {
+    const result = resolveApiKeyState("   ");
+
+    assert.strictEqual(result.isValid, false);
+    assert.deepStrictEqual(result.parts, []);
+    assert.strictEqual(result.secret, null);
+    assert.strictEqual(result.header, null);
+  });
+
+  it("should return isValid=false for null input", () => {
+    const result = resolveApiKeyState(null);
+
+    assert.strictEqual(result.isValid, false);
+    assert.deepStrictEqual(result.parts, []);
+    assert.strictEqual(result.secret, null);
+    assert.strictEqual(result.header, null);
+  });
+
+  it("should return isValid=false for undefined input", () => {
+    const result = resolveApiKeyState(undefined);
+
+    assert.strictEqual(result.isValid, false);
+    assert.deepStrictEqual(result.parts, []);
+    assert.strictEqual(result.secret, null);
+    assert.strictEqual(result.header, null);
+  });
+
+  it("should return isValid=false for object input", () => {
+    const result = resolveApiKeyState({});
+
+    assert.strictEqual(result.isValid, false);
+    assert.deepStrictEqual(result.parts, []);
+    assert.strictEqual(result.secret, null);
+    assert.strictEqual(result.header, null);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `resolveApiKeyState` function in `mcp-server.js` parses and validates API keys based on format, length, and presence of keys but was completely missing unit tests.

📊 **Coverage:** What scenarios are now tested
Added comprehensive tests covering:
- Valid API keys parsing.
- Whitespace trimming.
- Edge cases with dot placement (missing dot, extra dots).
- Inputs under length bounds (e.g. `secret` < 16 characters).
- Missing `keyId` or `secret` blocks.
- Non-string malformed inputs (`null`, `undefined`, objects).
- Blank/empty inputs.

✨ **Result:** The improvement in test coverage
The function `resolveApiKeyState` is fully tested across all logical branches, protecting it from any unintended refactoring regressions.

---
*PR created automatically by Jules for task [14734747995585734933](https://jules.google.com/task/14734747995585734933) started by @semihbugrasezer*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added unit tests for `resolveApiKeyState` in `mcp-server.js` to validate API key parsing and failure cases, improving reliability and preventing regressions.
Covers valid keys, whitespace trimming, missing/extra dots, short secrets, missing keyId/secret, non-string inputs, and empty values.

<sup>Written for commit 64caac672122393bff60e320358970b5fe16762f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

