### PR TITLE
🧪 Add tests for fetchJson utility function

### DIFF
--- a/tests/fetchJson.test.js
+++ b/tests/fetchJson.test.js
@@ -1,0 +1,148 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { fetchJson } from "../mcp-server.js";
+
+const originalFetch = global.fetch;
+
+describe("fetchJson", () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("should return parsed JSON data on 200 OK", async () => {
+    global.fetch = async () => ({
+      ok: true,
+      json: async () => ({ foo: "bar" }),
+    });
+
+    const data = await fetchJson("https://example.com/api");
+    assert.deepEqual(data, { foo: "bar" });
+  });
+
+  it("should return an empty object on 200 OK with invalid JSON", async () => {
+    global.fetch = async () => ({
+      ok: true,
+      json: async () => {
+        throw new Error("Invalid JSON");
+      },
+    });
+
+    const data = await fetchJson("https://example.com/api");
+    assert.deepEqual(data, {});
+  });
+
+  it("should throw an error with the `error` property when response is not ok", async () => {
+    global.fetch = async () => ({
+      ok: false,
+      status: 400,
+      headers: new Headers(),
+      json: async () => ({ error: "Bad Request from server" }),
+    });
+
+    await assert.rejects(
+      async () => await fetchJson("https://example.com/api"),
+      (err) => {
+        assert.strictEqual(err.message, "Bad Request from server");
+        assert.strictEqual(err.status, 400);
+        assert.deepEqual(err.payload, { error: "Bad Request from server" });
+        return true;
+      },
+    );
+  });
+
+  it("should throw an error with the `message` property when response is not ok", async () => {
+    global.fetch = async () => ({
+      ok: false,
+      status: 403,
+      headers: new Headers(),
+      json: async () => ({ message: "Forbidden access" }),
+    });
+
+    await assert.rejects(
+      async () => await fetchJson("https://example.com/api"),
+      (err) => {
+        assert.strictEqual(err.message, "Forbidden access");
+        assert.strictEqual(err.status, 403);
+        assert.deepEqual(err.payload, { message: "Forbidden access" });
+        return true;
+      },
+    );
+  });
+
+  it("should throw a fallback error message if JSON is empty or invalid on non-200 response", async () => {
+    global.fetch = async () => ({
+      ok: false,
+      status: 500,
+      headers: new Headers(),
+      json: async () => {
+        throw new Error("Invalid JSON");
+      },
+    });
+
+    await assert.rejects(
+      async () => await fetchJson("https://example.com/api"),
+      (err) => {
+        assert.strictEqual(err.message, "Request failed (500)");
+        assert.strictEqual(err.status, 500);
+        assert.strictEqual(err.payload, null);
+        return true;
+      },
+    );
+  });
+
+  it("should propagate fetch network errors", async () => {
+    global.fetch = async () => {
+      throw new Error("Network failure");
+    };
+
+    await assert.rejects(
+      async () => await fetchJson("https://example.com/api"),
+      (err) => {
+        assert.strictEqual(err.message, "Network failure");
+        return true;
+      },
+    );
+  });
+
+  it("should handle x-request-id header correctly on error", async () => {
+    const headers = new Headers();
+    headers.set("x-request-id", "req-123");
+    global.fetch = async () => ({
+      ok: false,
+      status: 500,
+      headers,
+      json: async () => ({ error: "Internal error" }),
+    });
+
+    await assert.rejects(
+      async () => await fetchJson("https://example.com/api"),
+      (err) => {
+        assert.strictEqual(err.message, "Internal error [request req-123]");
+        assert.strictEqual(err.requestId, "req-123");
+        return true;
+      },
+    );
+  });
+
+  it("should include code property on the error if available", async () => {
+    const headers = new Headers();
+    global.fetch = async () => ({
+      ok: false,
+      status: 429,
+      headers,
+      json: async () => ({
+        error: "Too Many Requests",
+        code: "RATE_LIMIT_EXCEEDED",
+      }),
+    });
+
+    await assert.rejects(
+      async () => await fetchJson("https://example.com/api"),
+      (err) => {
+        assert.strictEqual(err.message, "Too Many Requests");
+        assert.strictEqual(err.code, "RATE_LIMIT_EXCEEDED");
+        return true;
+      },
+    );
+  });
+});


### PR DESCRIPTION
🎯 **What:** Addresses the testing gap for the `fetchJson` utility function which lacked unit tests. The testing focuses on properly testing the logic since the function handles different types of API response errors, request IDs, error codes, and bad JSON gracefully.

📊 **Coverage:** The new tests in `tests/fetchJson.test.js` cover:
- Happy paths: 200 OK with valid JSON.
- 200 OK with invalid JSON returning `{}`.
- Non-200 responses with an `error` property in the response JSON.
- Non-200 responses with a `message` property in the response JSON.
- Non-200 responses with no specific error messages (fallback to generic request failed).
- Tests mapping header `x-request-id` into the thrown error.
- Tests mapping `code` properties into the thrown error (`RATE_LIMIT_EXCEEDED`).
- Tests that network failures propagate correctly.

✨ **Result:** Solid test coverage ensures modifications to `fetchJson` have a safety net and parsing/error extraction rules work flawlessly without requiring the live network.

---
*PR created automatically by Jules for task [4921251204129547238](https://jules.google.com/task/4921251204129547238) started by @semihbugrasezer*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `fetchJson` to validate JSON parsing and error handling, including request ID and error code propagation. Increases confidence and prevents regressions without hitting the network.

- **Test Coverage**
  - 200 OK with valid JSON; invalid JSON returns {}.
  - Non-200 with `error` or `message`; fallback to "Request failed (status)" when JSON is invalid/empty.
  - Maps `x-request-id` into error message and `requestId`.
  - Preserves `code` (e.g., `RATE_LIMIT_EXCEEDED`).
  - Propagates network failures.

<sup>Written for commit a459b0254af0e2ffbf784b5599ca8efa02251f9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

