### PR TITLE
🧪 [testing improvement description]

### DIFF
--- a/tests/getFlagValue.test.js
+++ b/tests/getFlagValue.test.js
@@ -1,0 +1,34 @@
+import { describe, it } from "node:test";
+import { strictEqual } from "node:assert";
+import { getFlagValue } from "../mcp-server.js";
+
+describe("getFlagValue", () => {
+  it("should return the value when flag is present with a valid value", () => {
+    const list = ["node", "script.js", "--foo", "bar"];
+    strictEqual(getFlagValue("foo", list), "bar");
+  });
+
+  it("should return null when the flag does not exist", () => {
+    const list = ["node", "script.js", "--bar", "baz"];
+    strictEqual(getFlagValue("foo", list), null);
+  });
+
+  it("should return null when the flag is the last item", () => {
+    const list = ["node", "script.js", "--foo"];
+    strictEqual(getFlagValue("foo", list), null);
+  });
+
+  it("should return null when the next item is another flag", () => {
+    const list = ["node", "script.js", "--foo", "--bar"];
+    strictEqual(getFlagValue("foo", list), null);
+  });
+
+  it("should return null when the list is empty", () => {
+    const list = [];
+    strictEqual(getFlagValue("foo", list), null);
+  });
+
+  it("should return null when the list is not provided", () => {
+    strictEqual(getFlagValue("foo"), null);
+  });
+});


### PR DESCRIPTION
🎯 What: Added test coverage for `getFlagValue` in `mcp-server.js` which previously lacked dedicated testing.
📊 Coverage: Tested happy path (flag exists with value), flag missing, flag at end of array (no value), next item is another flag, empty array, and default empty array cases.
✨ Result: `getFlagValue` is now fully tested across all possible edge cases, improving the reliability of command-line argument parsing.

---
*PR created automatically by Jules for task [1198237107848517954](https://jules.google.com/task/1198237107848517954) started by @semihbugrasezer*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added unit tests for `getFlagValue` in `mcp-server.js`.
Covers value present, missing flag, flag at end, next item is another flag, empty list, and no list to ensure robust CLI flag parsing.

<sup>Written for commit 7c991b898c9db1e3dee4ff44efa4fa38578c7ab8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

