### PR TITLE
🧪 Add tests for formatApiErrorMessage

### DIFF
--- a/tests/formatApiErrorMessage.test.js
+++ b/tests/formatApiErrorMessage.test.js
@@ -1,0 +1,73 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { formatApiErrorMessage } from "../mcp-server.js";
+
+describe("formatApiErrorMessage", () => {
+  test("returns specific message for status 401", () => {
+    const result = formatApiErrorMessage("Unauthorized access", 401);
+    assert.strictEqual(
+      result,
+      'Invalid API key (Unauthorized access). Run "seerxo login" to refresh credentials.',
+    );
+  });
+
+  test("returns specific message for status 403", () => {
+    const result = formatApiErrorMessage("Forbidden", 403);
+    assert.strictEqual(
+      result,
+      'Invalid API key (Forbidden). Run "seerxo login" to refresh credentials.',
+    );
+  });
+
+  test("returns specific message for status 401 with no message", () => {
+    const result = formatApiErrorMessage(undefined, 401);
+    assert.strictEqual(
+      result,
+      'Invalid API key. Run "seerxo login" to refresh credentials.',
+    );
+  });
+
+  test("returns specific message when message matches invalid api key patterns", () => {
+    const messages = [
+      "invalid api key",
+      "API KEY NOT FOUND",
+      "your api key is INACTIVE",
+    ];
+
+    for (const msg of messages) {
+      const result = formatApiErrorMessage(msg, 500);
+      assert.strictEqual(
+        result,
+        `Invalid API key (${msg}). Run "seerxo login" to refresh credentials.`,
+      );
+    }
+  });
+
+  test("returns original message for generic errors", () => {
+    const result = formatApiErrorMessage("Some server error", 500);
+    assert.strictEqual(result, "Some server error");
+  });
+
+  test("returns default generic message when message is falsy or non-string", () => {
+    const expected = "Failed to generate Etsy SEO content";
+    assert.strictEqual(formatApiErrorMessage(undefined, 500), expected);
+    assert.strictEqual(formatApiErrorMessage(null, 500), expected);
+    assert.strictEqual(formatApiErrorMessage("", 500), expected);
+    assert.strictEqual(formatApiErrorMessage({ error: "test" }, 500), expected);
+  });
+
+  test("appends requestId when provided", () => {
+    const result = formatApiErrorMessage("Server error", 500, "req_123");
+    assert.strictEqual(result, "Server error [request req_123]");
+
+    const invalidKeyResult = formatApiErrorMessage(
+      "Unauthorized",
+      401,
+      "req_456",
+    );
+    assert.strictEqual(
+      invalidKeyResult,
+      'Invalid API key (Unauthorized). Run "seerxo login" to refresh credentials. [request req_456]',
+    );
+  });
+});


### PR DESCRIPTION
🎯 **What:** Addressed a testing gap by adding tests for the `formatApiErrorMessage` function in `mcp-server.js`.
📊 **Coverage:** Added comprehensive tests for HTTP 401/403 status scenarios, API key invalidity string matching, fallback behaviors for generic error messages, missing or malformed input types, and the `requestId` suffix application logic.
✨ **Result:** Increased reliability and validation for user-facing API error rendering, ensuring that API key authentication problems correctly prompt the user rather than bubbling up confusing backend messages.

---
*PR created automatically by Jules for task [12137535083018218664](https://jules.google.com/task/12137535083018218664) started by @semihbugrasezer*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for formatApiErrorMessage to lock down error messaging and prevent regressions. Covers 401/403 handling (with and without messages), invalid API key pattern matching, default fallback for falsy/non‑string inputs, generic pass-through errors, and requestId suffixing.

<sup>Written for commit a90a368f89cd65e6a882aaa02522f829d5d8f376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

