### PR TITLE
fix: add request timeout to API calls

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -373,8 +373,37 @@ export const getFlagValue = (flag, list = []) => {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+// Generation calls proxy an LLM, so the default stays generous; override with
+// SEERXO_TIMEOUT_MS. No automatic retry: generate/optimize are metered POSTs
+// and a blind retry could double-spend credits.
+const FETCH_TIMEOUT_MS = (() => {
+  const parsed = parseInt(process.env.SEERXO_TIMEOUT_MS || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 120000;
+})();
+
+const isTimeoutError = (err) =>
+  err?.name === 'TimeoutError' ||
+  err?.name === 'AbortError' ||
+  err?.cause?.name === 'TimeoutError';
+
 export const fetchJson = async (url, options = {}) => {
-  const response = await fetch(url, options);
+  let response;
+  try {
+    response = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      ...options,
+    });
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      const error = new Error(
+        `Request timed out after ${Math.round(FETCH_TIMEOUT_MS / 1000)}s. ` +
+          `Check your connection, or raise SEERXO_TIMEOUT_MS if the server is just slow.`
+      );
+      error.code = 'timeout';
+      throw error;
+    }
+    throw err;
+  }
   let data = null;
   try {
     data = await response.json();

--- a/tests/fetchJson.test.js
+++ b/tests/fetchJson.test.js
@@ -90,6 +90,34 @@ describe("fetchJson", () => {
     );
   });
 
+  it("should pass an abort signal to fetch", async () => {
+    let seenSignal = null;
+    global.fetch = async (url, options) => {
+      seenSignal = options.signal;
+      return { ok: true, json: async () => ({}) };
+    };
+
+    await fetchJson("https://example.com/api");
+    assert.ok(seenSignal instanceof AbortSignal);
+  });
+
+  it("should map timeout aborts to a friendly error with code 'timeout'", async () => {
+    global.fetch = async () => {
+      const err = new Error("The operation was aborted due to timeout");
+      err.name = "TimeoutError";
+      throw err;
+    };
+
+    await assert.rejects(
+      async () => await fetchJson("https://example.com/api"),
+      (err) => {
+        assert.match(err.message, /timed out after \d+s/);
+        assert.strictEqual(err.code, "timeout");
+        return true;
+      },
+    );
+  });
+
   it("should propagate fetch network errors", async () => {
     global.fetch = async () => {
       throw new Error("Network failure");


### PR DESCRIPTION
## Summary
- `fetchJson` now passes `AbortSignal.timeout()` to every request; a hung connection previously blocked CLI commands and MCP tool calls forever (audit finding R1, `mcp-server.js:376`).
- Default 120s — generous because `/v1/generate` proxies an LLM — overridable via `SEERXO_TIMEOUT_MS`.
- Timeout aborts map to a friendly error with `code: 'timeout'`.
- Deliberately no retry: generate/optimize are metered POSTs; a blind retry could double-spend credits.

## Test plan
- [x] 67/67 tests pass locally (`NODE_ENV=test node --test`), including 2 new tests: signal is passed to fetch, TimeoutError maps to friendly error.
- [x] `node --check` on edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a request timeout to all API calls via fetchJson to prevent hung CLI commands and MCP tool calls. Uses AbortSignal.timeout with a 120s default (overridable via SEERXO_TIMEOUT_MS); timeouts return a friendly error with code 'timeout', and no automatic retry to avoid double-spend on metered POSTs.

<sup>Written for commit 337a1241d62b228b8feeae3b50ab4c5be4317af8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

