### PR TITLE
fix(deps): bump js-yaml to 4.3.0 to resolve OSV vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2179,9 +2179,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
GHSA-52cp-r559-cp3m (CVSS 7.5) via semantic-release > cosmiconfig > js-yaml@4.2.0, blocking OSV Scanner on all open dependabot PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `js-yaml` to 4.3.0 to fix GHSA-52cp-r559-cp3m in the `semantic-release` > `cosmiconfig` chain. This unblocks OSV Scanner and open Dependabot PRs.

<sup>Written for commit 36fc3764e0f98e1fe6e21db9fe8003d87834ca42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

