### PR TITLE
🧪 Add tests for initConfig

### DIFF
--- a/tests/initConfig.test.js
+++ b/tests/initConfig.test.js
@@ -1,6 +1,8 @@
 import { describe, it, mock, afterEach, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { promises as fsPromises } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import {
   initConfig,
   getRuntimeConfigState,
@@ -52,7 +54,7 @@ describe('initConfig', () => {
   });
 
   it('should fallback to local config when env vars are missing', async () => {
-    mock.method(fsPromises, 'readFile', async () => {
+    const readFileMock = mock.method(fsPromises, 'readFile', async () => {
       return JSON.stringify({
         email: 'local@example.com',
         apiKey: 'localKeyId.localSecret1234567890',
@@ -61,6 +63,11 @@ describe('initConfig', () => {
     });
 
     await initConfig();
+
+    assert.deepStrictEqual(readFileMock.mock.calls[0].arguments, [
+      path.join(os.homedir(), '.seerxo-mcp', 'config.json'),
+      'utf8',
+    ]);
 
     const state = getRuntimeConfigState();
     assert.strictEqual(state.email, 'local@example.com');

--- a/tests/initConfig.test.js
+++ b/tests/initConfig.test.js
@@ -1,0 +1,113 @@
+import { describe, it, mock, afterEach, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fsPromises } from 'node:fs';
+import {
+  initConfig,
+  getRuntimeConfigState,
+  setRuntimeConfig,
+} from '../mcp-server.js';
+import { DEFAULT_HOST } from '../utils.js';
+
+describe('initConfig', () => {
+  let originalEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    // Clear relevant environment variables to ensure a clean state
+    delete process.env.SEERXO_EMAIL;
+    delete process.env.EMAIL;
+    delete process.env.SEERXO_API_KEY;
+    delete process.env.MCP_API_KEY;
+    delete process.env.SEERXO_HOST;
+    delete process.env.API_BASE;
+
+    // Clear runtime config state
+    setRuntimeConfig({ email: null, apiKey: null, host: DEFAULT_HOST });
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    mock.restoreAll();
+  });
+
+  it('should use environment variables over local config', async () => {
+    process.env.SEERXO_EMAIL = 'env@example.com';
+    process.env.SEERXO_API_KEY = 'envKeyId.envSecret1234567890';
+    process.env.SEERXO_HOST = 'https://env.api.com';
+
+    mock.method(fsPromises, 'readFile', async () => {
+      return JSON.stringify({
+        email: 'local@example.com',
+        apiKey: 'localKeyId.localSecret1234567890',
+        host: 'https://local.api.com',
+      });
+    });
+
+    await initConfig();
+
+    const state = getRuntimeConfigState();
+    assert.strictEqual(state.email, 'env@example.com');
+    assert.strictEqual(state.host, 'https://env.api.com');
+    assert.strictEqual(state.hasValidApiKey, true);
+  });
+
+  it('should fallback to local config when env vars are missing', async () => {
+    mock.method(fsPromises, 'readFile', async () => {
+      return JSON.stringify({
+        email: 'local@example.com',
+        apiKey: 'localKeyId.localSecret1234567890',
+        host: 'https://local.api.com',
+      });
+    });
+
+    await initConfig();
+
+    const state = getRuntimeConfigState();
+    assert.strictEqual(state.email, 'local@example.com');
+    assert.strictEqual(state.host, 'https://local.api.com');
+    assert.strictEqual(state.hasValidApiKey, true);
+  });
+
+  it('should use DEFAULT_HOST and nulls when both env vars and local config are missing', async () => {
+    mock.method(fsPromises, 'readFile', async () => {
+      return '{}';
+    });
+
+    await initConfig();
+
+    const state = getRuntimeConfigState();
+    assert.strictEqual(state.email, null);
+    assert.strictEqual(state.host, DEFAULT_HOST);
+    assert.strictEqual(state.hasValidApiKey, false);
+  });
+
+  it('should handle fsPromises.readFile throwing an error (e.g. file not found)', async () => {
+    mock.method(fsPromises, 'readFile', async () => {
+      throw new Error('ENOENT: no such file or directory');
+    });
+
+    await initConfig();
+
+    const state = getRuntimeConfigState();
+    assert.strictEqual(state.email, null);
+    assert.strictEqual(state.host, DEFAULT_HOST);
+    assert.strictEqual(state.hasValidApiKey, false);
+  });
+
+  it('should use secondary env vars (EMAIL, MCP_API_KEY, API_BASE) if primary ones are absent', async () => {
+    process.env.EMAIL = 'secondary@example.com';
+    process.env.MCP_API_KEY = 'secondaryKeyId.secondarySecret123456';
+    process.env.API_BASE = 'https://secondary.api.com';
+
+    mock.method(fsPromises, 'readFile', async () => {
+      return '{}';
+    });
+
+    await initConfig();
+
+    const state = getRuntimeConfigState();
+    assert.strictEqual(state.email, 'secondary@example.com');
+    assert.strictEqual(state.host, 'https://secondary.api.com');
+    assert.strictEqual(state.hasValidApiKey, true);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The `initConfig` function in `mcp-server.js` was missing dedicated unit tests. This function is critical for resolving configuration paths and managing internal module states correctly based on user local configurations and environment variables.

📊 **Coverage:** The new tests in `tests/initConfig.test.js` cover the following scenarios:
*   Precedence of environment variables (`SEERXO_EMAIL`, `SEERXO_API_KEY`, `SEERXO_HOST`) over local config.
*   Graceful fallback to local config when no environment variables are set.
*   Default fallback values (e.g., `DEFAULT_HOST`, `null` for emails/keys) when neither is present.
*   Handling of `fsPromises.readFile` errors appropriately.
*   Validation of secondary environment variables (`EMAIL`, `MCP_API_KEY`, `API_BASE`).

✨ **Result:** Enhanced test coverage that guards against unintended config-loading changes in the future, increasing code reliability for the MCP initialization process!

---
*PR created automatically by Jules for task [16189776816412583979](https://jules.google.com/task/16189776816412583979) started by @semihbugrasezer*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `initConfig` in `mcp-server.js` covering env var precedence (incl. secondary), fallback to and path of local config, `DEFAULT_HOST` defaults, and `fsPromises.readFile` errors. Improves reliability of config loading and MCP startup.

<sup>Written for commit 277a2c614c80f081aceafa265f26cf752dfecc94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

