### PR TITLE
🧪 Testing Improvement: fetchJson timeout error handling

### DIFF
--- a/tests/fetchJson.test.js
+++ b/tests/fetchJson.test.js
@@ -118,6 +118,41 @@ describe("fetchJson", () => {
     );
   });
 
+  it("should map AbortError to a friendly error with code 'timeout'", async () => {
+    global.fetch = async () => {
+      const err = new Error("The operation was aborted");
+      err.name = "AbortError";
+      throw err;
+    };
+
+    await assert.rejects(
+      async () => await fetchJson("https://example.com/api"),
+      (err) => {
+        assert.match(err.message, /timed out after \d+s/);
+        assert.strictEqual(err.code, "timeout");
+        return true;
+      },
+    );
+  });
+
+  it("should map nested cause TimeoutError to a friendly error with code 'timeout'", async () => {
+    global.fetch = async () => {
+      const err = new Error("fetch failed");
+      err.cause = new Error("The operation was aborted due to timeout");
+      err.cause.name = "TimeoutError";
+      throw err;
+    };
+
+    await assert.rejects(
+      async () => await fetchJson("https://example.com/api"),
+      (err) => {
+        assert.match(err.message, /timed out after \d+s/);
+        assert.strictEqual(err.code, "timeout");
+        return true;
+      },
+    );
+  });
+
   it("should propagate fetch network errors", async () => {
     global.fetch = async () => {
       throw new Error("Network failure");


### PR DESCRIPTION
🎯 **What:** Added tests for the remaining conditions in `isTimeoutError` to ensure complete coverage of fetch timeout scenarios.
📊 **Coverage:** Specifically added tests for when `fetch` throws an error with `name === 'AbortError'` and when the error has a nested cause with `name === 'TimeoutError'`.
✨ **Result:** Improved test coverage for `fetchJson` error handling, ensuring these edge cases properly reject with a timeout error.

---
*PR created automatically by Jules for task [17399910003574382118](https://jules.google.com/task/17399910003574382118) started by @semihbugrasezer*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests to cover `fetchJson` timeout handling for `AbortError` and nested `cause.name === 'TimeoutError'`, ensuring both map to a friendly error with code `timeout`. This fills the remaining gaps in `isTimeoutError` coverage and helps prevent regressions.

<sup>Written for commit 21734477347ffecb4544111b111603d21ca560aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

