### PR TITLE
fix: make tests portable across supported environments

### DIFF
--- a/tests/initConfig.test.js
+++ b/tests/initConfig.test.js
@@ -64,8 +64,11 @@ describe('initConfig', () => {
 
     await initConfig();
 
+    const expectedConfigDir = process.env.SEERXO_CONFIG_DIR
+      ? path.resolve(process.env.SEERXO_CONFIG_DIR)
+      : path.join(os.homedir(), '.seerxo-mcp');
     assert.deepStrictEqual(readFileMock.mock.calls[0].arguments, [
-      path.join(os.homedir(), '.seerxo-mcp', 'config.json'),
+      path.join(expectedConfigDir, 'config.json'),
       'utf8',
     ]);
 

--- a/tests/openUrlInBrowser.test.js
+++ b/tests/openUrlInBrowser.test.js
@@ -21,7 +21,12 @@ describe("openUrlInBrowser", () => {
 
     openUrlInBrowser("https://example.com");
     assert.strictEqual(openMock.mock.calls.length, 0);
-    assert.strictEqual(consoleErrorMock.mock.calls.length, 0);
+    assert.strictEqual(
+      consoleErrorMock.mock.calls.filter(({ arguments: [message] }) =>
+        String(message).startsWith("Failed to open browser"),
+      ).length,
+      0,
+    );
   });
 
   it("should catch and log error if open rejects", async () => {
@@ -42,10 +47,14 @@ describe("openUrlInBrowser", () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     assert.strictEqual(openMock.mock.calls.length, 1);
-    assert.strictEqual(consoleErrorMock.mock.calls.length, 1);
+    const expectedMessage = chalk.yellow(
+      `Failed to open browser automatically: ${errorMsg}`,
+    );
     assert.strictEqual(
-      consoleErrorMock.mock.calls[0].arguments[0],
-      chalk.yellow(`Failed to open browser automatically: ${errorMsg}`),
+      consoleErrorMock.mock.calls.filter(
+        ({ arguments: [message] }) => message === expectedMessage,
+      ).length,
+      1,
     );
   });
 
@@ -64,10 +73,14 @@ describe("openUrlInBrowser", () => {
     openUrlInBrowser("https://example.com");
 
     assert.strictEqual(openMock.mock.calls.length, 1);
-    assert.strictEqual(consoleErrorMock.mock.calls.length, 1);
+    const expectedMessage = chalk.yellow(
+      `Failed to invoke browser opener: ${errorMsg}`,
+    );
     assert.strictEqual(
-      consoleErrorMock.mock.calls[0].arguments[0],
-      chalk.yellow(`Failed to invoke browser opener: ${errorMsg}`),
+      consoleErrorMock.mock.calls.filter(
+        ({ arguments: [message] }) => message === expectedMessage,
+      ).length,
+      1,
     );
   });
 });


### PR DESCRIPTION
## What changed

- Ignore unrelated Node runtime warnings while still asserting each browser-open failure message exactly once.
- Derive the `initConfig` test expectation from `SEERXO_CONFIG_DIR` when present.

## Why

Node 26 emits an `esmock` `module.register()` deprecation warning through `console.error`, which broke a global exact-call-count assertion. The `initConfig` test also hard-coded the default config path even when `SEERXO_CONFIG_DIR` configured another path.

## Impact

Test-only change; no CLI or MCP production behavior changes. The conventional `fix:` title also lets semantic-release create the patch release that prior emoji-titled squash commits did not trigger.

## Checks

- Node 26: `npm test` (103/103)
- Node 20: `npm test` (103/103)
- Custom `SEERXO_CONFIG_DIR` targeted test
- `npm run lint`
- `npm run build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the tests portable across Node 20 and 26, and respect custom config directories by deriving the expected path from `SEERXO_CONFIG_DIR`. Test-only change; no CLI or MCP behavior changes.

- **Bug Fixes**
  - `openUrlInBrowser` tests: check `console.error` only for “Failed to open browser…” messages and assert exactly once. This ignores unrelated Node 26 `esmock` deprecation warnings.
  - `initConfig` test: derive the expected config path from `SEERXO_CONFIG_DIR` if set; fallback to `~/.seerxo-mcp/config.json`.

<sup>Written for commit 33408fc1345a5da81b5eb962facc6332d5cf5cbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

