### PR TITLE
CLI/MCP: Listing Readiness sözleşmesini konuş

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ each tag ≤20 chars, lowercase, no duplicates.
 | 🖥️ **CLI** | Terminal lovers, scripts, batch work | `npm i -g seerxo` |
 | 🤖 **Claude Desktop (MCP)** | "Generate a listing" mid-conversation | [Setup ↓](#claude-desktop-mcp) |
 | 🧑‍💻 **Claude Code skill** | Listings without leaving your editor | `seerxo skill add` |
-| 🌐 **[Web app](https://www.seerxo.com)** | Zero install + free [SEO Score audit](https://www.seerxo.com/audit) | Open and type |
+| 🌐 **[Web app](https://www.seerxo.com)** | Zero install + free [Listing Readiness check](https://www.seerxo.com/audit) | Open and type |
 
 One account, one credit pool — every channel shares it.
 
@@ -73,7 +73,7 @@ seerxo generate --product "boho macrame wall hanging" --category "Home & Living"
 Already have a listing? Score it, fix it, and mine keywords from the same CLI:
 
 ```bash
-seerxo analyze  --title "Minimalist Mug" --tags "mug,gift" --description "..."   # SEO score + weak points
+seerxo analyze  --title "Minimalist Mug" --tags "mug,gift" --description "..."   # sourced readiness findings
 seerxo optimize --title "Minimalist Mug" --tags "mug,gift" --description "..."   # guided rewrite, before/after score
 seerxo keywords --seed "ceramic mug"                                             # ranked Etsy autosuggest keywords
 ```

--- a/skills/seerxo-etsy-seo/SKILL.md
+++ b/skills/seerxo-etsy-seo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: seerxo-etsy-seo
-description: Generate, audit, optimize, and research keywords for Etsy listings through the Seerxo remote MCP server or CLI. Use when a user wants an Etsy title, description, 13 tags, SEO score, listing rewrite, keyword ideas, quota help, or help connecting and testing Seerxo with Claude or ChatGPT.
+description: Generate, check readiness, apply guided fixes, and research keywords for Etsy listings through the Seerxo remote MCP server or CLI. Use when a user wants an Etsy title, description, 13 tags, Listing Readiness check, listing rewrite, keyword ideas, quota help, or help connecting and testing Seerxo with Claude or ChatGPT.
 ---
 
 ![Seerxo Etsy SEO](https://raw.githubusercontent.com/semihbugrasezer/seerxo/main/skills/seerxo-etsy-seo/assets/seerxo-banner.svg)
@@ -26,7 +26,7 @@ tool result without silently adding claims, materials, measurements, or keyword 
 | Intent | MCP tool | CLI fallback | Usage |
 | --- | --- | --- | --- |
 | Create a listing | `generate_etsy_seo` | `seerxo generate` | 1 AI action |
-| Score an existing listing | `seerxo_analyze_listing` | `seerxo analyze` | Free |
+| Check an existing listing | `seerxo_analyze_listing` | `seerxo analyze` | Free |
 | Rewrite weak fields | `seerxo_optimize_listing` | `seerxo optimize` | 1 AI action |
 | Find keyword ideas | `seerxo_suggest_keywords` | `seerxo keywords` | 1 AI action |
 | Check account usage | `seerxo_quota` | `seerxo status` | Free |
@@ -77,10 +77,13 @@ seerxo analyze --title "Speckled Ceramic Coffee Mug" --tags "handmade mug,cerami
 
 Present:
 
-- overall `seoScore` out of 100 and the title, tags, description, and completeness scores;
-- weak points in severity order as `reason → fix`;
+- canonical `overallScore` out of 100, `scoringVersion`, and the title, tags, description, and completeness readiness scores;
+- weak points in severity order as `reason → fix`, with each finding's source;
 - missing keywords without inventing search volume;
-- tag use as `used/13`, followed by duplicates, broad tags, and overlong tags.
+- tag use as `used/13`, followed by duplicates, broad tags, and overlong tags;
+- returned limitations, including that readiness does not predict rank, traffic, conversion, or sales.
+
+Treat `seoScore` only as a deprecated compatibility alias for `overallScore`.
 
 If no weak points are returned, say the listing passed the audit; do not manufacture work.
 

--- a/src/formatters/listing.js
+++ b/src/formatters/listing.js
@@ -1,7 +1,7 @@
 export function formatAnalyzeResult(data) {
   const s = data.subScores || {};
   const weakPoints = (data.weakPoints || [])
-    .map((wp, i) => `${i + 1}. [${wp.severity}] (${wp.field}) ${wp.reason} — fix: ${wp.fix}`)
+    .map((wp, i) => `${i + 1}. [${wp.severity}] (${wp.field}) ${wp.reason} — fix: ${wp.fix}${wp.source?.url ? ` — [source](${wp.source.url})` : ''}`)
     .join('\n');
   const util = data.tagUtilization || {};
   const utilNotes = [
@@ -9,13 +9,16 @@ export function formatAnalyzeResult(data) {
     util.overLong?.length ? `over 20 chars: ${util.overLong.join(', ')}` : '',
     util.tooBroad?.length ? `single-word (too broad): ${util.tooBroad.join(', ')}` : '',
   ].filter(Boolean).join(' · ');
+  const score = data.overallScore ?? data.seoScore ?? 'n/a';
+  const limitations = (data.limitations || []).map((item) => `- ${item}`).join('\n');
 
   return (
-    `# Listing Audit\n\n` +
-    `**SEO Score: ${data.seoScore}/100** — title ${s.title}, tags ${s.tags}, description ${s.description}, completeness ${s.completeness}\n\n` +
+    `# Listing Readiness\n\n` +
+    `**Listing Readiness: ${score}/100**${data.scoringVersion ? ` · rubric ${data.scoringVersion}` : ''} — title ${s.title}, tags ${s.tags}, description ${s.description}, completeness ${s.completeness}\n\n` +
     `## Weak points\n${weakPoints || 'None — this listing passes every check.'}\n\n` +
     `## Missing keywords\n${(data.missingKeywords || []).join(', ') || 'none'}\n\n` +
-    `## Tag slots\n${util.used}/${util.max} used${utilNotes ? ` (${utilNotes})` : ''}`
+    `## Tag slots\n${util.used}/${util.max} used${utilNotes ? ` (${utilNotes})` : ''}` +
+    `${limitations ? `\n\n## Limitations\n${limitations}` : ''}`
   );
 }
 
@@ -29,10 +32,12 @@ export function formatOptimizeResult(data) {
   const modeNote = data.mode && data.mode !== 'full'
     ? ` · only the ${data.mode.replace('_only', '')} was rewritten`
     : '';
+  const beforeScore = before.overallScore ?? before.seoScore ?? 'n/a';
+  const afterScore = after.overallScore ?? after.seoScore ?? 'n/a';
 
   return (
-    `# Optimized Listing\n\n` +
-    `**SEO Score: ${before.seoScore} → ${after.seoScore}** · resolved ${data.resolved?.length ?? 0} finding(s)` +
+    `# Guided Listing Fix\n\n` +
+    `**Listing Readiness: ${beforeScore} → ${afterScore}** · resolved ${data.resolved?.length ?? 0} finding(s)` +
     `${data.unresolved?.length ? `, still open: ${data.unresolved.join(', ')}` : ''}${modeNote}${fallbackNote}\n\n` +
     `## Title\n${optimized.title}\n\n` +
     `## Description\n${optimized.description}\n\n` +
@@ -50,4 +55,3 @@ export function formatKeywordsResult(data) {
     `${rows || 'No suggestions found for this seed.'}`
   );
 }
-

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -24,34 +24,54 @@ const STRING_ARRAY_SCHEMA = {
 
 const SUB_SCORES_SCHEMA = {
   type: 'object',
-  description: 'SEO scores from 0 to 100 for each listing area.',
+  description: 'Listing Readiness scores from 0 to 100 for each supported listing area.',
   properties: {
-    title: { type: 'number', description: 'Title SEO score from 0 to 100.' },
-    tags: { type: 'number', description: 'Tags SEO score from 0 to 100.' },
-    description: { type: 'number', description: 'Description SEO score from 0 to 100.' },
+    title: { type: 'number', description: 'Title readiness from 0 to 100.' },
+    tags: { type: 'number', description: 'Tag readiness from 0 to 100.' },
+    description: { type: 'number', description: 'Description readiness from 0 to 100.' },
     completeness: { type: 'number', description: 'Listing completeness score from 0 to 100.' },
   },
   required: ['title', 'tags', 'description', 'completeness'],
 };
 
+const SOURCE_EVIDENCE_SCHEMA = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    source: { type: 'string' },
+    title: { type: 'string' },
+    url: { type: 'string', format: 'uri' },
+  },
+  required: ['id', 'source', 'title', 'url'],
+};
+
 const WEAK_POINT_SCHEMA = {
   type: 'object',
   properties: {
-    id: { type: 'string', description: 'Stable identifier for the failed SEO check.' },
+    id: { type: 'string', description: 'Stable identifier for the failed readiness check.' },
+    ruleId: { type: 'string', description: 'Versioned deterministic rule identifier.' },
     field: { type: 'string', description: 'Listing field that needs improvement.' },
     severity: { type: 'string', enum: ['high', 'medium', 'low'], description: 'Priority of the finding.' },
     reason: { type: 'string', description: 'Human-readable explanation of the finding.' },
+    explanation: { type: 'string', description: 'Why the deterministic check failed.' },
     fix: { type: 'string', description: 'Concrete action that resolves the finding.' },
+    source: SOURCE_EVIDENCE_SCHEMA,
   },
-  required: ['id', 'field', 'severity', 'reason', 'fix'],
+  required: ['id', 'ruleId', 'field', 'severity', 'reason', 'explanation', 'fix', 'source'],
 };
 
 const AUDIT_OUTPUT_SCHEMA = {
   type: 'object',
   properties: {
-    seoScore: { type: 'number', description: 'Overall Etsy SEO score from 0 to 100.' },
+    scoringVersion: { type: 'string', const: 'etsy-guidance-2026-04-27' },
+    scoreType: { type: 'string', const: 'listing_readiness' },
+    overallScore: { type: 'number', description: 'Deterministic Listing Readiness score from 0 to 100; not a rank or sales prediction.' },
+    evaluatedAt: { type: 'string', format: 'date-time' },
+    evidence: { type: 'array', items: SOURCE_EVIDENCE_SCHEMA },
+    limitations: { ...STRING_ARRAY_SCHEMA, description: 'What the submitted-field audit cannot measure or predict.' },
+    seoScore: { type: 'number', deprecated: true, description: 'Compatibility alias for overallScore.' },
     subScores: SUB_SCORES_SCHEMA,
-    weakPoints: { type: 'array', items: WEAK_POINT_SCHEMA, description: 'Ranked SEO findings and fixes.' },
+    weakPoints: { type: 'array', items: WEAK_POINT_SCHEMA, description: 'Ranked, sourced readiness findings and fixes.' },
     missingKeywords: { ...STRING_ARRAY_SCHEMA, description: 'Product keywords missing from the listing.' },
     tagUtilization: {
       type: 'object',
@@ -66,15 +86,15 @@ const AUDIT_OUTPUT_SCHEMA = {
       required: ['used', 'max', 'duplicates', 'tooBroad', 'overLong'],
     },
   },
-  required: ['seoScore', 'subScores', 'weakPoints', 'missingKeywords', 'tagUtilization'],
+  required: ['scoringVersion', 'scoreType', 'overallScore', 'evaluatedAt', 'evidence', 'limitations', 'seoScore', 'subScores', 'weakPoints', 'missingKeywords', 'tagUtilization'],
 };
 
 const LISTING_OUTPUT_SCHEMA = {
   type: 'object',
   properties: {
-    title: { type: 'string', description: 'SEO-optimized Etsy listing title.' },
-    description: { type: 'string', description: 'SEO-optimized Etsy listing description.' },
-    tags: { ...STRING_ARRAY_SCHEMA, description: 'SEO-optimized Etsy tags.' },
+    title: { type: 'string', description: 'Etsy listing title draft.' },
+    description: { type: 'string', description: 'Etsy listing description draft.' },
+    tags: { ...STRING_ARRAY_SCHEMA, description: 'Etsy listing tag drafts.' },
   },
   required: ['title', 'description', 'tags'],
 };
@@ -179,13 +199,13 @@ export const LISTING_TOOLS = [
   },
   {
     name: 'seerxo_analyze_listing',
-    title: 'Analyze Etsy Listing',
+    title: 'Check Etsy Listing Readiness',
     description:
-      'Audit an existing Etsy listing. Returns an SEO score (0-100) with per-field sub-scores, ranked weak points (each with severity and a concrete fix), missing keywords, and tag-slot utilization. Call it with whatever listing fields are available (title, tags, description); at least one is required.',
+      'Check an existing Etsy listing against a versioned deterministic readiness rubric. Returns sourced findings, per-field readiness scores, explicit limitations, missing product terms, and tag-slot utilization. It does not predict rank, traffic, conversion, or sales. Call it with whatever listing fields are available; at least one is required.',
     inputSchema: { type: 'object', properties: LISTING_INPUT_PROPERTIES, required: [] },
     outputSchema: AUDIT_OUTPUT_SCHEMA,
     annotations: {
-      title: 'Analyze Etsy Listing',
+      title: 'Check Etsy Listing Readiness',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -194,9 +214,9 @@ export const LISTING_TOOLS = [
   },
   {
     name: 'seerxo_optimize_listing',
-    title: 'Optimize Etsy Listing',
+    title: 'Apply Guided Listing Fixes',
     description:
-      'Rewrite an Etsy listing to fix its audit findings: improved title, description, and tag set, each mapped to the finding it resolves, with a before/after SEO score. Etsy limits (140-char title, 13 tags, 20 chars per tag) are enforced server-side and the result never scores below the original. Provide the current listing fields.',
+      'Rewrite an Etsy listing to address sourced readiness findings, with complete before/after audits. Etsy limits (140-char title, 13 tags, 20 chars per tag) are enforced server-side and a rewrite that lowers the deterministic readiness score is rejected. Provide the current listing fields.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -212,27 +232,9 @@ export const LISTING_TOOLS = [
     outputSchema: {
       type: 'object',
       properties: {
-        before: {
-          type: 'object',
-          description: 'Audit summary before optimization.',
-          properties: {
-            seoScore: { type: 'number', description: 'Original SEO score from 0 to 100.' },
-            subScores: SUB_SCORES_SCHEMA,
-            weakPoints: { type: 'array', items: WEAK_POINT_SCHEMA, description: 'Original SEO findings.' },
-          },
-          required: ['seoScore', 'subScores', 'weakPoints'],
-        },
+        before: AUDIT_OUTPUT_SCHEMA,
         optimized: LISTING_OUTPUT_SCHEMA,
-        after: {
-          type: 'object',
-          description: 'Audit summary after optimization.',
-          properties: {
-            seoScore: { type: 'number', description: 'Optimized SEO score from 0 to 100.' },
-            subScores: SUB_SCORES_SCHEMA,
-            weakPoints: { type: 'array', items: WEAK_POINT_SCHEMA, description: 'SEO findings that remain.' },
-          },
-          required: ['seoScore', 'subScores', 'weakPoints'],
-        },
+        after: AUDIT_OUTPUT_SCHEMA,
         resolved: { ...STRING_ARRAY_SCHEMA, description: 'Finding IDs resolved by the rewrite.' },
         unresolved: { ...STRING_ARRAY_SCHEMA, description: 'Finding IDs still present after the rewrite.' },
         diff: { type: 'object', description: 'Before and after values for each listing field.' },
@@ -242,7 +244,7 @@ export const LISTING_TOOLS = [
       required: ['before', 'optimized', 'after', 'resolved', 'unresolved', 'diff', 'fallback', 'mode'],
     },
     annotations: {
-      title: 'Optimize Etsy Listing',
+      title: 'Apply Guided Listing Fixes',
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: false,

--- a/tests/listing-tools.test.js
+++ b/tests/listing-tools.test.js
@@ -60,6 +60,14 @@ describe('listing tool definitions', () => {
       'tags_only',
     ]);
   });
+
+  it('publishes the versioned Listing Readiness contract', () => {
+    const analyzeTool = LISTING_TOOLS.find((t) => t.name === 'seerxo_analyze_listing');
+    assert.ok(analyzeTool.outputSchema.required.includes('overallScore'));
+    assert.ok(analyzeTool.outputSchema.required.includes('scoringVersion'));
+    assert.strictEqual(analyzeTool.outputSchema.properties.seoScore.deprecated, true);
+    assert.ok(analyzeTool.outputSchema.properties.weakPoints.items.required.includes('source'));
+  });
 });
 
 describe('buildListingPayload', () => {
@@ -152,10 +160,20 @@ describe('versioned API contract', () => {
 
 describe('formatters', () => {
   const audit = {
+    scoringVersion: 'etsy-guidance-2026-04-27',
+    scoreType: 'listing_readiness',
+    overallScore: 62,
     seoScore: 62,
+    evaluatedAt: '2026-08-30T12:00:00.000Z',
+    evidence: [],
+    limitations: ['This score does not predict search rank, traffic, conversion, or sales.'],
     subScores: { title: 80, tags: 40, description: 100, completeness: 66 },
     weakPoints: [
-      { id: 'tags_count', field: 'tags', severity: 'high', reason: 'Exactly 13 tags', fix: 'Use all 13 tag slots.' },
+      {
+        id: 'tags_count', ruleId: 'tags.use-all-slots', field: 'tags', severity: 'high',
+        reason: 'Exactly 13 tags', explanation: 'Etsy provides 13 tag slots.', fix: 'Use all 13 tag slots.',
+        source: { id: 'etsy-keywords', source: 'Etsy', title: 'Keywords 101', url: 'https://www.etsy.com/seller-handbook/article/382774281517' },
+      },
     ],
     missingKeywords: ['12oz'],
     tagUtilization: { used: 7, max: 13, duplicates: ['mug'], tooBroad: ['mug'], overLong: [] },
@@ -164,6 +182,11 @@ describe('formatters', () => {
   it('renders an audit as readable markdown with score, fixes, and tag slots', () => {
     const text = formatAnalyzeResult(audit);
     assert.ok(text.includes('62/100'));
+    assert.ok(text.includes('Listing Readiness'));
+    assert.ok(!text.includes('SEO Score'));
+    assert.ok(text.includes('etsy-guidance-2026-04-27'));
+    assert.ok(text.includes('https://www.etsy.com/seller-handbook/article/382774281517'));
+    assert.ok(text.includes('does not predict search rank'));
     assert.ok(text.includes('[high] (tags) Exactly 13 tags — fix: Use all 13 tag slots.'));
     assert.ok(text.includes('12oz'));
     assert.ok(text.includes('7/13 used'));
@@ -172,14 +195,16 @@ describe('formatters', () => {
 
   it('renders an optimize result with before/after and the rewritten fields', () => {
     const text = formatOptimizeResult({
-      before: { seoScore: 40 },
-      after: { seoScore: 95 },
+      before: { overallScore: 40, seoScore: 39 },
+      after: { overallScore: 95, seoScore: 94 },
       optimized: { title: 'New Title', description: 'New description.', tags: ['a b', 'c d'] },
       resolved: ['tags_count', 'desc_present'],
       unresolved: ['tags_multiword'],
       fallback: false,
     });
     assert.ok(text.includes('40 → 95'));
+    assert.ok(text.includes('Listing Readiness'));
+    assert.ok(!text.includes('SEO Score'));
     assert.ok(text.includes('resolved 2 finding(s)'));
     assert.ok(text.includes('still open: tags_multiword'));
     assert.ok(text.includes('New Title'));


### PR DESCRIPTION
## Ne değişti
- `analyze` / `optimize` output şemaları artık `scoringVersion`, `scoreType`, `overallScore`, `evaluatedAt`, `evidence`, `limitations` zorunlu tutuyor; `seoScore` sadece `deprecated` uyumluluk alias'ı.
- Weak point'ler `ruleId`, `explanation` ve `source` istiyor; formatter her bulguyu `reason → fix` olarak, Etsy kaynağına link vererek basıyor.
- Skor satırı: `**Listing Readiness: N/100** · rubric <version>`.
- README ve `skills/seerxo-etsy-seo/SKILL.md` skorun ne olduğunu **ve ne olmadığını** söylüyor.

## Doğrulama
- `npm test` → 104/104 pass
- `npm run lint` (`node --check` zinciri) → temiz
- `npm run build` → package validation passed

## Bağımlılık
semihbugrasezer/seerxo-backend#105 önce merge olmalı — bu şema onun çıktısını doğruluyor (`scoringVersion` const olarak `etsy-guidance-2026-04-27`'e pinli).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches CLI/MCP `analyze` and `optimize` outputs from a legacy SEO score to a versioned Listing Readiness contract with sourced findings and explicit limitations. `seoScore` stays as a deprecated compatibility alias; no behavior changes for consumers that ignored it.

- Output schemas now require `scoringVersion`, `scoreType`, `overallScore`, `evaluatedAt`, `evidence`, and `limitations`.
- Weak points now require `ruleId`, `explanation`, and `source`; the formatter renders each finding as `reason → fix` with a link to its Etsy source.
- The score line now reads `Listing Readiness: N/100 · rubric <version>`, and README and skill docs state what the score does and does not predict.
- `optimize` now rejects rewrites that lower the deterministic readiness score.
- Depends on `semihbugrasezer/seerxo-backend#105`, which must merge before this schema's pinned `scoringVersion` output is validated.

<sup>Written for commit ef478ec47404183f3428a48996ed1a395e48251c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

