### PR TITLE
docs: replace broken Smithery badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![npm](https://img.shields.io/npm/v/seerxo?color=a78bfa&label=npm)](https://www.npmjs.com/package/seerxo)
 [![npm downloads](https://img.shields.io/npm/dw/seerxo?logo=npm)](https://www.npmjs.com/package/seerxo)
 [![MCP](https://img.shields.io/badge/MCP-Compatible-blue)](https://modelcontextprotocol.io)
-[![smithery badge](https://smithery.ai/badge/seerxo)](https://smithery.ai/servers/seerxo)
+[![LightNow MCP capabilities](https://lightnow.ai/badge/io.github.semihbugrasezer/seerxo)](https://lightnow.ai/servers/io.github.semihbugrasezer/seerxo)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GitHub stars](https://img.shields.io/github/stars/semihbugrasezer/seerxo?style=social)](https://github.com/semihbugrasezer/seerxo)
 


### PR DESCRIPTION
Replaces the broken Smithery badge with LightNow.

LightNow currently reports **5 T · 0 R · 0 P** for this server.

- [Server listing](https://lightnow.ai/servers/io.github.semihbugrasezer/seerxo)
- [Badge documentation and variants](https://docs.lightnow.ai/how-to/add-capability-badge)

Verification: exact README-only diff; badge and destination return HTTP 200.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the broken Smithery badge in the README with a working LightNow capability badge. LightNow reports 5 T · 0 R · 0 P for this server, and both the badge and its destination return HTTP 200.

<sup>Written for commit b5c44e71f7d7027283bc671548c2bd1066edd786. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semihbugrasezer/seerxo/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

